### PR TITLE
Auth-gateway-authorizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
 
 # terraform files
 terraform/.terraform/providers/*
-terraform/terraform.tfstate
+*terraform.tfstate*
+terraform/terraform.tfvars
 terraform/terraform.tfstate.backup
 # lambda dependencies
 **/lambda-dependency-package/
 **/node_modules/
+**/build
+backend/**/*.zip
 
 # default node configuration
 # Logs

--- a/backend/auth-token-authorizer/index.js
+++ b/backend/auth-token-authorizer/index.js
@@ -17,19 +17,9 @@ function generatePolicy(principalId, effect, resource) {
   return authResponse;
 }
 
-const getCookieValue = (cookieString, cookieName) => {
-  const cookies = cookieString.split("; ");
-  for (let cookie of cookies) {
-    const [name, value] = cookie.split("=");
-    if (name === cookieName) return value;
-  }
-  return null;
-};
-
 exports.handler = async (event) => {
-  const cookies = event.headers.Cookie || event.headers.cookie;
+  const accessToken = event.headers["login-auth-token"];
   try {
-    const accessToken = getCookieValue(cookies, "accessToken");
     const decodedToken = jwt.verify(accessToken, process.env.JWT_SECRET);
     const userId = decodedToken.userId;
     console.log("User ID from JWT:", userId);

--- a/backend/auth-token-authorizer/index.js
+++ b/backend/auth-token-authorizer/index.js
@@ -19,21 +19,32 @@ function generatePolicy(principalId, effect, resource) {
 
 exports.handler = async (event) => {
   const accessToken = event.headers["login-auth-token"];
+  // Broader arn for less invocations
+  const methodArn = event.methodArn;
+  const arnParts = methodArn.split(":");
+  const apiGatewayArn = arnParts[5].split("/");
+  const region = arnParts[3];
+  const accountId = arnParts[4];
+  const apiId = apiGatewayArn[0];
+  const stage = apiGatewayArn[1];
   try {
     const decodedToken = jwt.verify(accessToken, process.env.JWT_SECRET);
     const userId = decodedToken.userId;
-    console.log("User ID from JWT:", userId);
+    console.log(
+      "Permitting",
+      `arn:aws:execute-api:${region}:${accountId}:${apiId}/${stage}/*/*`
+    );
     return generatePolicy(
       userId,
       "Allow",
-      `arn:aws:execute-api:${event.region}:${event.accountId}:${event.apiId}/${event.stage}/*/*`
+      `arn:aws:execute-api:${region}:${accountId}:${apiId}/${stage}/*/*`
     );
   } catch (error) {
     console.error("JWT verification failed:", error);
     return generatePolicy(
       "user",
       "Deny",
-      `arn:aws:execute-api:${event.region}:${event.accountId}:${event.apiId}/${event.stage}/*/*`
+      `arn:aws:execute-api:${region}:${accountId}:${apiId}/${stage}/*/*`
     );
   }
 };

--- a/backend/auth-token-authorizer/index.js
+++ b/backend/auth-token-authorizer/index.js
@@ -1,0 +1,49 @@
+const jwt = require("jsonwebtoken");
+
+function generatePolicy(principalId, effect, resource) {
+  const authResponse = {
+    principalId: principalId,
+    policyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Action: "execute-api:Invoke",
+          Effect: effect,
+          Resource: resource,
+        },
+      ],
+    },
+  };
+  return authResponse;
+}
+
+const getCookieValue = (cookieString, cookieName) => {
+  const cookies = cookieString.split("; ");
+  for (let cookie of cookies) {
+    const [name, value] = cookie.split("=");
+    if (name === cookieName) return value;
+  }
+  return null;
+};
+
+exports.handler = async (event) => {
+  const cookies = event.headers.Cookie || event.headers.cookie;
+  try {
+    const accessToken = getCookieValue(cookies, "accessToken");
+    const decodedToken = jwt.verify(accessToken, process.env.JWT_SECRET);
+    const userId = decodedToken.userId;
+    console.log("User ID from JWT:", userId);
+    return generatePolicy(
+      userId,
+      "Allow",
+      `arn:aws:execute-api:${event.region}:${event.accountId}:${event.apiId}/${event.stage}/*/*`
+    );
+  } catch (error) {
+    console.error("JWT verification failed:", error);
+    return generatePolicy(
+      "user",
+      "Deny",
+      `arn:aws:execute-api:${event.region}:${event.accountId}:${event.apiId}/${event.stage}/*/*`
+    );
+  }
+};

--- a/backend/lambda-edge-cookie-parser/index.js
+++ b/backend/lambda-edge-cookie-parser/index.js
@@ -1,0 +1,18 @@
+exports.handler = (event, context, callback) => {
+  const request = event.Records[0].cf.request;
+  const headers = request.headers;
+
+  if (headers.cookie) {
+    const cookies = headers.cookie[0].value.split("; ");
+    const accessToken = cookies
+      .find((cookie) => cookie.startsWith("accessToken="))
+      ?.split("=")[1];
+
+    if (accessToken) {
+      headers.authorization = [{ key: "Authorization", value: accessToken }];
+    }
+    delete headers.cookie; // Remove cookie from the request
+  }
+
+  callback(null, request);
+};

--- a/backend/lambda-edge-cookie-parser/index.js
+++ b/backend/lambda-edge-cookie-parser/index.js
@@ -9,7 +9,9 @@ exports.handler = (event, context, callback) => {
       ?.split("=")[1];
 
     if (accessToken) {
-      headers.authorization = [{ key: "Authorization", value: accessToken }];
+      headers["login-auth-token"] = [
+        { key: "login-auth-token", value: accessToken },
+      ];
     }
     delete headers.cookie; // Remove cookie from the request
   }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -103,7 +103,7 @@ resource "aws_lambda_permission" "allow_apigateway_invocation" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.node_auth_token_creation.arn
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "arn:aws:execute-api:us-west-1:${data.aws_caller_identity.current.account_id}:vae1x9x8se/*/POST/users_auth"
+  source_arn    = "arn:aws:execute-api:us-west-1:${data.aws_caller_identity.current.account_id}:${var.api_id}/*/POST/users_auth"
 }
 
 
@@ -131,7 +131,7 @@ resource "aws_lambda_permission" "allow_apigateway_invocation_invalidation" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.node_auth_token_invalidation.arn
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "arn:aws:execute-api:us-west-1:${data.aws_caller_identity.current.account_id}:vae1x9x8se/*/POST/users_auth/logout"
+  source_arn    = "arn:aws:execute-api:us-west-1:${data.aws_caller_identity.current.account_id}:${var.api_id}/*/POST/users_auth/logout"
 }
 
 
@@ -168,7 +168,7 @@ resource "aws_lambda_permission" "allow_apigateway_invocation_refresh" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.node_auth_token_refresh.arn
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "arn:aws:execute-api:us-west-1:${data.aws_caller_identity.current.account_id}:vae1x9x8se/*/POST/users_auth/refresh"
+  source_arn    = "arn:aws:execute-api:us-west-1:${data.aws_caller_identity.current.account_id}:${var.api_id}/*/POST/users_auth/refresh"
 }
 
 
@@ -210,7 +210,7 @@ resource "aws_lambda_permission" "allow_apigateway_invocation_authorizer" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.node_auth_token_refresh.arn
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "arn:aws:execute-api:us-west-1:${data.aws_caller_identity.current.account_id}:vae1x9x8se/*/POST/*/*"
+  source_arn    = "arn:aws:execute-api:us-west-1:${data.aws_caller_identity.current.account_id}:${var.api_id}/*/POST/*/*"
 }
 
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -242,6 +242,27 @@ resource "aws_lambda_permission" "api_gateway_auth" {
   source_arn    = "${aws_api_gateway_rest_api.user_data_api.execution_arn}/*/*"
 }
 
+resource "aws_iam_policy" "lambda_invoke_policy" {
+  name        = "lambda-invoke-policy"
+  description = "Policy to allow API Gateway to invoke Lambda authorizer"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "lambda:InvokeFunction"
+        ],
+        Effect = "Allow",
+        Resource = aws_lambda_function.node_auth_token_authorizer.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "api_gateway_lambda_invoke" {
+  role       = aws_iam_role.api_gateway_authorizer_role.name
+  policy_arn = aws_iam_policy.lambda_invoke_policy.arn
+}
 
 resource "aws_api_gateway_authorizer" "login_token_gateway_authorizer" {
   name            = "TokenAuthorizer"

--- a/terraform/lambdaedge.tf
+++ b/terraform/lambdaedge.tf
@@ -1,0 +1,127 @@
+
+# S3 Bucket in us-east-1 for Lambda@Edge code
+resource "aws_s3_bucket" "pbars_lambdas_edge_bucket" {
+  provider = aws.us_east_1
+  bucket   = "pbars-lambda-edge-bucket"
+}
+
+### token authorizer
+resource "aws_s3_bucket_object" "lambda_edge_cookie_parser" {
+  provider = aws.us_east_1 
+  bucket = aws_s3_bucket.pbars_lambdas_edge_bucket.bucket
+  source = "../backend/lambda-edge-cookie-parser/lambda-edge-cookie-parser.zip"
+  key    = "lambda-edge-cookie-parser.zip"
+  content_type  = "application/zip"
+  etag = filemd5("../backend/lambda-edge-cookie-parser/lambda-edge-cookie-parser.zip")
+}
+
+# Lambda@Edge Function , has to be us east 1
+resource "aws_lambda_function" "lambda_edge_cookie_parser" {
+  provider = aws.us_east_1 
+  function_name = "lambda-edge-cookie-parser"
+  handler       = "index.handler"
+  s3_bucket     = aws_s3_bucket.pbars_lambdas_edge_bucket.bucket
+  s3_key        = aws_s3_bucket_object.lambda_edge_cookie_parser.key
+
+  runtime = "nodejs22.x"  
+  depends_on = [aws_s3_bucket_object.lambda_edge_cookie_parser]
+  publish       = true # Required for Lambda@Edge
+
+  role = aws_iam_role.lambda_edge_role.arn
+  timeout = 5
+  memory_size = 128
+}
+
+# iam needs lamnda & edge lambda
+resource "aws_iam_role" "lambda_edge_role" {
+  name = "lambda-edge-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = ["lambda.amazonaws.com", "edgelambda.amazonaws.com"]
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "lambda_edge_policy" {
+  name = "lambda-edge-policy"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        Effect = "Allow",
+        Resource = "arn:aws:logs:*:*:log-group:/aws/lambda/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_edge_policy_attach" {
+  role       = aws_iam_role.lambda_edge_role.name
+  policy_arn = aws_iam_policy.lambda_edge_policy.arn
+}
+
+# CloudFront Distribution
+resource "aws_cloudfront_distribution" "api_cloudfront_distribution" {
+  origin {
+    domain_name =  element(split("/", replace("${aws_api_gateway_deployment.user_data_deployment.invoke_url}", "https://", "")), 0)
+    origin_id   = "APIGatewayOrigin"
+
+    custom_origin_config {
+      http_port             = 80
+      https_port            = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "APIGatewayOrigin"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "all"
+      }
+      headers = ["Authorization"]
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    lambda_function_association {
+      event_type   = "viewer-request"
+      lambda_arn   = "${aws_lambda_function.lambda_edge_cookie_parser.arn}:${aws_lambda_function.lambda_edge_cookie_parser.version}"
+      include_body = true
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,3 +12,8 @@ variable "jwt_secret" {
   description = "String used for jwt tokens"
   type        = string
 }
+
+variable "api_id" {
+  description = "api gateway id"
+  type = string
+}


### PR DESCRIPTION
Session login validation with custom lambda api gateway authorizer. The lambda api gateway authorizer can be configured on endpoints in method request settings / authorization. It checks for valid jwt and allows or denies actual endpoints fetched. 
Session login authorizer can't read cookies so api gateway cloudfront distrubtion was created for lambda@edge to strip cookies from fetches and add to "login-auth-token" header. This was the option with less latency & components vs multiple lambdas & endpoints to strip cookies and pass downstream to authorizer. The cloudfront distribution is now used for fetch urls instead of api execute.

Testing
- [x] lambda@edge generated header 'login-auth-token' showing up in downstream functions node-auth-token-creation console.log(event.headers) 
- [x] allow case
    - curl -v -X POST cloudfrontdistribution.cloudfront.net/endpoint/test -H "Content-Type:applicaton/json" -b"accessToken=valid"
    - 200 , whatever endpoint success is
- [x] fail case
    - curl -v -X POST cloudfrontdistribution.cloudfront.net/endpoint/test -H "Content-Type:applicaton/json" -b"accessToken=invalid"
    - 403 , {"message":"User is not authorized to access this resource with an explicit deny"}

Components
- cloudfront distrubtion
- lambda-edge-cookie-parser
- node-auth-token-authorizer
- api/authorizers/TokenAuthorizer