### PR TITLE
Frontend auth hook

### DIFF
--- a/backend/auth-token-creation/index.js
+++ b/backend/auth-token-creation/index.js
@@ -18,7 +18,7 @@ const streamToString = (stream) =>
   });
 
 const corsHeaders = {
-  "Access-Control-Allow-Origin": "https://www.year-progress-bar.com",
+  "Access-Control-Allow-Origin": "https://year-progress-bar.com",
   "Access-Control-Allow-Methods": "POST",
   "Access-Control-Allow-Headers":
     "Content-Type, Authorization, Origin, X-Amz-Date, X-Api-Key, X-Amz-Security-Token",

--- a/backend/auth-token-creation/index.js
+++ b/backend/auth-token-creation/index.js
@@ -156,7 +156,7 @@ exports.handler = async (event) => {
       }),
       headers: {
         ...corsHeaders,
-        "Set-Cookie": `refreshToken=${refreshCookieToken}; Path=/; Max-Age=36000; HttpOnly; SameSite=None`,
+        "Set-Cookie": `refreshToken=${refreshCookieToken}; Path=/; Max-Age=691200; HttpOnly; SameSite=None`,
         "set-cookie": `accessToken=${cookieToken}; Path=/; Max-Age=3600; HttpOnly; SameSite=None`,
       },
     };

--- a/backend/auth-token-invalidation/index.js
+++ b/backend/auth-token-invalidation/index.js
@@ -76,7 +76,7 @@ exports.handler = async (event) => {
         message: "Access token missing from cookies.",
       }),
       headers: {
-        "Access-Control-Allow-Origin": "https://www.year-progress-bar.com", // Frontend
+        "Access-Control-Allow-Origin": "https://year-progress-bar.com", // Frontend
         "Access-Control-Allow-Methods": "POST",
         "Access-Control-Allow-Headers":
           "Content-Type, Authorization, Origin, X-Amz-Date, X-Api-Key, X-Amz-Security-Token",
@@ -95,7 +95,7 @@ exports.handler = async (event) => {
       message: "Login invalidated",
     }),
     headers: {
-      "Access-Control-Allow-Origin": "https://www.year-progress-bar.com", // Frontend
+      "Access-Control-Allow-Origin": "https://year-progress-bar.com", // Frontend
       "Access-Control-Allow-Methods": "POST",
       "Access-Control-Allow-Headers":
         "Content-Type, Authorization, Origin, X-Amz-Date, X-Api-Key, X-Amz-Security-Token",

--- a/backend/auth-token-refresh/index.js
+++ b/backend/auth-token-refresh/index.js
@@ -8,7 +8,7 @@ const jwt = require("jsonwebtoken");
 
 const dynamoClient = new DynamoDBClient({ region: "us-west-1" });
 const corsheaders = {
-  "Access-Control-Allow-Origin": "https://www.year-progress-bar.com",
+  "Access-Control-Allow-Origin": "https://year-progress-bar.com",
   "Access-Control-Allow-Methods": "POST",
   "Access-Control-Allow-Headers":
     "Content-Type, Authorization, Origin, X-Amz-Date, X-Api-Key, X-Amz-Security-Token",

--- a/backend/success-response/index.js
+++ b/backend/success-response/index.js
@@ -1,5 +1,5 @@
 const corsheaders = {
-  "Access-Control-Allow-Origin": "https://www.year-progress-bar.com",
+  "Access-Control-Allow-Origin": "https://year-progress-bar.com",
   "Access-Control-Allow-Methods": "POST",
   "Access-Control-Allow-Headers":
     "Content-Type, Authorization, Origin, X-Amz-Date, X-Api-Key, X-Amz-Security-Token",

--- a/backend/success-response/index.js
+++ b/backend/success-response/index.js
@@ -1,0 +1,19 @@
+const corsheaders = {
+  "Access-Control-Allow-Origin": "https://www.year-progress-bar.com",
+  "Access-Control-Allow-Methods": "POST",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Authorization, Origin, X-Amz-Date, X-Api-Key, X-Amz-Security-Token",
+  "Access-Control-Allow-Credentials": "true",
+};
+
+exports.handler = (event, context, callback) => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: "Validated",
+    }),
+    headers: {
+      ...corsheaders,
+    },
+  };
+};

--- a/frontend-web/index.html
+++ b/frontend-web/index.html
@@ -24,7 +24,7 @@
       property="twitter:image"
       content="https://s3.us-west-1.amazonaws.com/year-progress-bar.com/images/site-screenshot.png"
     />
-    <meta property="og:url" content="https://www.year-progress-bar.com" />
+    <meta property="og:url" content="https://year-progress-bar.com" />
 
     <link rel="icon" type="image/svg+xml" href="/tab-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend-web/src/App.jsx
+++ b/frontend-web/src/App.jsx
@@ -2,7 +2,6 @@ import "./index-output.css";
 import ProgressBar from "./ProgressBar";
 import Settings from "./routes/Settings";
 import Login from "./routes/Login";
-import Day from "./routes/Day";
 import { AuthProvider } from "./hooks/useAuth";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
@@ -14,7 +13,6 @@ function App() {
           <Route path="/" element={<ProgressBar />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="/login" element={<Login />} />
-          <Route path="/day" element={<Day />} />
         </Routes>
       </Router>
     </AuthProvider>

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.82.2"
+  hashes = [
+    "h1:ce6Dw2y4PpuqAPtnQ0dO270dRTmwEARqnfffrE1VYJ8=",
+    "zh:0262fc96012fb7e173e1b7beadd46dfc25b1dc7eaef95b90e936fc454724f1c8",
+    "zh:397413613d27f4f54d16efcbf4f0a43c059bd8d827fe34287522ae182a992f9b",
+    "zh:436c0c5d56e1da4f0a4c13129e12a0b519d12ab116aed52029b183f9806866f3",
+    "zh:4d942d173a2553d8d532a333a0482a090f4e82a2238acf135578f163b6e68470",
+    "zh:624aebc549bfbce06cc2ecfd8631932eb874ac7c10eb8466ce5b9a2fbdfdc724",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e632dee2dfdf01b371cca7854b1ec63ceefa75790e619b0642b34d5514c6733",
+    "zh:a07567acb115b60a3df8f6048d12735b9b3bcf85ec92a62f77852e13d5a3c096",
+    "zh:ab7002df1a1be6432ac0eb1b9f6f0dd3db90973cd5b1b0b33d2dae54553dfbd7",
+    "zh:bc1ff65e2016b018b3e84db7249b2cd0433cb5c81dc81f9f6158f2197d6b9fde",
+    "zh:bcad84b1d767f87af6e1ba3dc97fdb8f2ad5de9224f192f1412b09aba798c0a8",
+    "zh:cf917dceaa0f9d55d9ff181b5dcc4d1e10af21b6671811b315ae2a6eda866a2a",
+    "zh:d8e90ecfb3216f3cc13ccde5a16da64307abb6e22453aed2ac3067bbf689313b",
+    "zh:d9054e0e40705df729682ad34c20db8695d57f182c65963abd151c6aba1ab0d3",
+    "zh:ecf3a4f3c57eb7e89f71b8559e2a71e4cdf94eea0118ec4f2cb37e4f4d71a069",
+  ]
+}

--- a/terraform/apigateway.tf
+++ b/terraform/apigateway.tf
@@ -188,7 +188,7 @@ resource "aws_api_gateway_integration_response" "auth_options_integration_respon
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'OPTIONS,POST'"
-    "method.response.header.Access-Control-Allow-Origin" = "'https://www.year-progress-bar.com'"
+    "method.response.header.Access-Control-Allow-Origin" = "'https://year-progress-bar.com'"
     "method.response.header.Access-Control-Allow-Credentials": "'true'"
   }
 
@@ -196,7 +196,7 @@ resource "aws_api_gateway_integration_response" "auth_options_integration_respon
     "application/json" = jsonencode({
       statusCode = 200
       headers = {
-        "Access-Control-Allow-Origin"      = "'https://www.year-progress-bar.com'"
+        "Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'"
         "Access-Control-Allow-Methods"     = "POST, OPTIONS"
         "Access-Control-Allow-Headers"     = "Content-Type, Authorization, Origin, X-Amz-Date, X-Api-Key, X-Amz-Security-Token"
         "Access-Control-Allow-Credentials" = "'true'" # Client expects string
@@ -303,7 +303,7 @@ resource "aws_api_gateway_integration_response" "auth_logout_options_integration
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,POST'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://www.year-progress-bar.com'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 
@@ -407,7 +407,7 @@ resource "aws_api_gateway_integration_response" "auth_refresh_options_integratio
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,POST'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://www.year-progress-bar.com'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 
@@ -510,7 +510,7 @@ resource "aws_api_gateway_integration_response" "auth_check_options_integration_
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,POST'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://www.year-progress-bar.com'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }

--- a/terraform/apigateway.tf
+++ b/terraform/apigateway.tf
@@ -455,7 +455,8 @@ resource "aws_api_gateway_method" "auth_check_post_method" {
   rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
   resource_id   = aws_api_gateway_resource.users_auth_check.id
   http_method   = "POST"
-  authorization = "NONE"
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.login_token_gateway_authorizer.id
 }
 
 resource "aws_api_gateway_method" "auth_check_options_method" {

--- a/terraform/apigateway.tf
+++ b/terraform/apigateway.tf
@@ -103,6 +103,7 @@ resource "aws_api_gateway_deployment" "user_data_deployment" {
       aws_api_gateway_integration.auth_logout_options_integration,
       aws_api_gateway_method_response.auth_logout_options_method_response,
       aws_api_gateway_integration_response.auth_logout_options_integration_response
+      # login check
     ]))
   }
 }
@@ -429,6 +430,107 @@ resource "aws_api_gateway_method_response" "refresh_user_response" {
   rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
   resource_id   = aws_api_gateway_method.refresh_post_method.resource_id
   http_method   = aws_api_gateway_method.refresh_post_method.http_method
+  status_code   = "200"
+
+  response_parameters = {
+      "method.response.header.Access-Control-Allow-Origin": true,
+      "method.response.header.Access-Control-Allow-Headers": true,
+      "method.response.header.Access-Control-Allow-Methods": true,
+      "method.response.header.Access-Control-Allow-Credentials": true,
+
+  }
+}
+
+
+
+#### auth check
+
+resource "aws_api_gateway_resource" "users_auth_check" {
+  rest_api_id = aws_api_gateway_rest_api.user_data_api.id
+  parent_id   = aws_api_gateway_resource.users_auth.id
+  path_part   = "auth_check"
+}
+
+resource "aws_api_gateway_method" "auth_check_post_method" {
+  rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
+  resource_id   = aws_api_gateway_resource.users_auth_check.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method" "auth_check_options_method" {
+  rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
+  resource_id   = aws_api_gateway_resource.users_auth_check.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "auth_check_options_integration" {
+  rest_api_id = aws_api_gateway_rest_api.user_data_api.id
+  resource_id = aws_api_gateway_resource.users_auth_check.id
+  http_method = "OPTIONS"
+  type        = "MOCK" 
+
+  request_templates = {
+    "application/json" = jsonencode({ statusCode = 200 })
+  }
+
+  passthrough_behavior = "WHEN_NO_MATCH"
+
+  depends_on = [aws_api_gateway_method.auth_check_options_method]
+}
+
+resource "aws_api_gateway_method_response" "auth_check_options_method_response" {
+  rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
+  resource_id   = aws_api_gateway_resource.users_auth_check.id
+  http_method   = "OPTIONS"
+  status_code   = "200"
+  depends_on = [aws_api_gateway_method.auth_check_options_method]
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers"     = true,
+    "method.response.header.Access-Control-Allow-Methods"     = true,
+    "method.response.header.Access-Control-Allow-Origin"      = true,
+    "method.response.header.Access-Control-Allow-Credentials" = true
+  }
+}
+
+resource "aws_api_gateway_integration_response" "auth_check_options_integration_response" {
+  rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
+  resource_id   = aws_api_gateway_resource.users_auth_check.id
+  http_method   = "OPTIONS"
+  status_code   = "200"
+
+  depends_on = [
+    aws_api_gateway_integration.auth_check_options_integration,
+    aws_api_gateway_method_response.auth_check_options_method_response
+  ]
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+    "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,POST'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://www.year-progress-bar.com'",
+    "method.response.header.Access-Control-Allow-Credentials" = "'true'"
+  }
+}
+
+resource "aws_api_gateway_integration" "auth_check_lambda_integration" {
+  rest_api_id = aws_api_gateway_rest_api.user_data_api.id
+  resource_id = aws_api_gateway_method.auth_check_post_method.resource_id
+  http_method = aws_api_gateway_method.auth_check_post_method.http_method
+  type                    = "AWS_PROXY"
+  integration_http_method = "POST"
+  credentials             = null
+  request_parameters = {}
+  request_templates = {}
+  uri = aws_lambda_function.node_success_response.invoke_arn
+  passthrough_behavior = "WHEN_NO_MATCH" 
+}
+
+resource "aws_api_gateway_method_response" "auth_check_response" {
+  rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
+  resource_id   = aws_api_gateway_method.auth_check_post_method.resource_id
+  http_method   = aws_api_gateway_method.auth_check_post_method.http_method
   status_code   = "200"
 
   response_parameters = {


### PR DESCRIPTION
- single initial api call in useAuth to check http cookies with custom tokenauthorizer
- call also performed after login flow triggered
- login state set in useauth hook & available throughout App.jsx with import useAuthContext
- also lengthened refresh token to 2 weeks for now
- removed www. from cors urls

deployed resources
- options & post method for /users_auth/auth_check
- node-success-response lambda function for 200 response after authorizer passes

testing
- working on frontend, currently works for https://year-progress-bar.com/login not https://www.year-progress-bar.com, route53 needs to have redirect
- console log on separate page ie routes/Settings.jsx
```
import { useAuthContext } from "../hooks/useAuth";
const { isSignedIn, handleGoogleSignIn, handleSignOut } = useAuthContext();
console.log(isSignedIn);
```