### PR TITLE
cloudfront domain rename

### DIFF
--- a/backend/auth-token-creation/index.js
+++ b/backend/auth-token-creation/index.js
@@ -18,7 +18,7 @@ const streamToString = (stream) =>
   });
 
 const corsHeaders = {
-  "Access-Control-Allow-Origin": "https://localhost:5173",
+  "Access-Control-Allow-Origin": "https://year-progress-bar.com",
   "Access-Control-Allow-Methods": "POST",
   "Access-Control-Allow-Headers":
     "Content-Type, Authorization, Origin, X-Amz-Date, X-Api-Key, X-Amz-Security-Token",
@@ -156,8 +156,8 @@ exports.handler = async (event) => {
       }),
       headers: {
         ...corsHeaders,
-        "Set-Cookie": `refreshToken=${refreshCookieToken}; Path=/; Max-Age=691200; HttpOnly; SameSite=None; domain=year-progress-bar.com`,
-        "set-cookie": `accessToken=${cookieToken}; Path=/; Max-Age=3600; HttpOnly; SameSite=None; domain=year-progress-bar.com`,
+        "Set-Cookie": `refreshToken=${refreshCookieToken}; Path=/; Max-Age=691200; HttpOnly; SameSite=None; Domain=year-progress-bar.com`,
+        "set-cookie": `accessToken=${cookieToken}; Path=/; Max-Age=3600; HttpOnly; SameSite=None; Domain=year-progress-bar.com`,
       },
     };
   } catch (error) {

--- a/backend/auth-token-creation/index.js
+++ b/backend/auth-token-creation/index.js
@@ -18,7 +18,7 @@ const streamToString = (stream) =>
   });
 
 const corsHeaders = {
-  "Access-Control-Allow-Origin": "https://year-progress-bar.com",
+  "Access-Control-Allow-Origin": "https://localhost:5173",
   "Access-Control-Allow-Methods": "POST",
   "Access-Control-Allow-Headers":
     "Content-Type, Authorization, Origin, X-Amz-Date, X-Api-Key, X-Amz-Security-Token",
@@ -156,8 +156,8 @@ exports.handler = async (event) => {
       }),
       headers: {
         ...corsHeaders,
-        "Set-Cookie": `refreshToken=${refreshCookieToken}; Path=/; Max-Age=691200; HttpOnly; SameSite=None`,
-        "set-cookie": `accessToken=${cookieToken}; Path=/; Max-Age=3600; HttpOnly; SameSite=None`,
+        "Set-Cookie": `refreshToken=${refreshCookieToken}; Path=/; Max-Age=691200; HttpOnly; SameSite=None; domain=year-progress-bar.com`,
+        "set-cookie": `accessToken=${cookieToken}; Path=/; Max-Age=3600; HttpOnly; SameSite=None; domain=year-progress-bar.com`,
       },
     };
   } catch (error) {

--- a/backend/auth-token-invalidation/index.js
+++ b/backend/auth-token-invalidation/index.js
@@ -100,7 +100,7 @@ exports.handler = async (event) => {
       "Access-Control-Allow-Headers":
         "Content-Type, Authorization, Origin, X-Amz-Date, X-Api-Key, X-Amz-Security-Token",
       "Access-Control-Allow-Credentials": "true", // for cookies
-      "Set-Cookie": `accessToken=; Path=/; HttpOnly; Expires=${pastDate}; Secure; SameSite=None`,
+      "Set-Cookie": `accessToken=; Path=/; HttpOnly; Expires=${pastDate}; Secure; SameSite=None; Domain=year-progress-bar.com`,
     },
   };
 };

--- a/backend/auth-token-refresh/index.js
+++ b/backend/auth-token-refresh/index.js
@@ -140,8 +140,8 @@ exports.handler = async (event) => {
       }),
       headers: {
         ...corsheaders,
-        "Set-Cookie": `refreshToken=${refreshCookieToken}; Path=/; HttpOnly; Max-Age=36000; Secure; SameSite=None`,
-        "set-cookie": `accessToken=${cookieToken}; Path=/; Max-Age=3600; HttpOnly; SameSite=None`,
+        "Set-Cookie": `refreshToken=${refreshCookieToken}; Path=/; HttpOnly; Max-Age=36000; Secure; SameSite=None; Domain=year-progress-bar.com`,
+        "set-cookie": `accessToken=${cookieToken}; Path=/; Max-Age=3600; HttpOnly; SameSite=None; Domain=year-progress-bar.com`,
       },
     };
   }

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -161,3 +161,35 @@ resource "aws_cloudfront_distribution" "api_cloudfront_distribution" {
   }
 }
 
+
+resource "aws_route53_record" "cloudfront_cname" {
+  zone_id = data.aws_route53_zone.progress_bars_domain.zone_id 
+  name    = "api.year-progress-bar.com"
+  type    = "CNAME"
+  ttl     = "300"
+  records = [aws_cloudfront_distribution.api_cloudfront_distribution.domain_name]
+}
+
+resource "aws_acm_certificate" "api_subdomain_cert" {
+  provider          = aws.us_east_1
+  domain_name       = "api.year-progress-bar.com"
+  validation_method = "DNS"
+}
+
+
+resource "aws_route53_record" "api_subdomain_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.api_subdomain_cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.progress_bars_domain.zone_id 
+}


### PR DESCRIPTION
Changes domain for cloudfront to subdomain of website, http only cookie login working on mobile browsers now.

fixes https://github.com/isabelfaulds/yearly-progress-bars/issues/15

todos
- [x] cname for subdomain
- [x] acm certificate for https
- [x] cloudfront update
- [x] change cookie set domain
- [x] test
    - [x] curl
    - [x] frontend
    - [x] mobile