### PR TITLE
Day Route

### DIFF
--- a/frontend-web/src/App.jsx
+++ b/frontend-web/src/App.jsx
@@ -1,5 +1,6 @@
 import "./index-output.css";
-import ProgressBar from "./ProgressBar";
+import ProgressBar from "./routes/ProgressBar";
+import Day from "./routes/Day";
 import Settings from "./routes/Settings";
 import Login from "./routes/Login";
 import { AuthProvider } from "./hooks/useAuth";
@@ -13,6 +14,7 @@ function App() {
           <Route path="/" element={<ProgressBar />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="/login" element={<Login />} />
+          <Route path="/day-view" element={<Day />} />
         </Routes>
       </Router>
     </AuthProvider>

--- a/frontend-web/src/App.jsx
+++ b/frontend-web/src/App.jsx
@@ -1,7 +1,9 @@
 import "./index-output.css";
 import ProgressBar from "./routes/ProgressBar";
 import Day from "./routes/Day";
-import Settings from "./routes/Settings";
+import Settings from "./routes/BarSettings";
+import CategorySettings from "./routes/CategorySettings";
+
 import Login from "./routes/Login";
 import { AuthProvider } from "./hooks/useAuth";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
@@ -13,11 +15,11 @@ function App() {
       <Router>
         <Routes>
           <Route path="/" element={<ProgressBar />} />
-          <Route path="/settingss" element={<Settings />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/day-view/settings" element={<CategorySettings />} />
           <Route path="/login" element={<Login />} />
           <Route path="/day-view" element={<Day />} />
         </Routes>
-        {/* <NavButton /> */}
       </Router>
     </AuthProvider>
   );

--- a/frontend-web/src/App.jsx
+++ b/frontend-web/src/App.jsx
@@ -5,6 +5,7 @@ import Settings from "./routes/Settings";
 import Login from "./routes/Login";
 import { AuthProvider } from "./hooks/useAuth";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import NavButton from "./components/NavButton";
 
 function App() {
   return (
@@ -12,10 +13,11 @@ function App() {
       <Router>
         <Routes>
           <Route path="/" element={<ProgressBar />} />
-          <Route path="/settings" element={<Settings />} />
+          <Route path="/settingss" element={<Settings />} />
           <Route path="/login" element={<Login />} />
           <Route path="/day-view" element={<Day />} />
         </Routes>
+        {/* <NavButton /> */}
       </Router>
     </AuthProvider>
   );

--- a/frontend-web/src/components/NavButton.jsx
+++ b/frontend-web/src/components/NavButton.jsx
@@ -9,26 +9,27 @@ import { useNavigate } from "react-router-dom";
 function NavButton() {
   const [showIcons, setShowIcons] = useState(false);
   const buttonRef = useRef(null);
+  const menuRef = useRef(null);
   const navigate = useNavigate();
 
   const handleClick = () => {
-    setShowIcons(!showIcons);
+    setShowIcons((prev) => !prev);
   };
 
   const handleOutsideClick = (event) => {
-    if (buttonRef.current && !buttonRef.current.contains(event.target)) {
+    if (
+      buttonRef.current &&
+      !buttonRef.current.contains(event.target) &&
+      menuRef.current &&
+      !menuRef.current.contains(event.target)
+    ) {
       setShowIcons(false);
     }
   };
 
-  const handleHomeClick = () => {
-    navigate("/");
+  const handleNavigation = (path) => {
     setShowIcons(false);
-  };
-
-  const handleSettingsClick = () => {
-    navigate("/settings");
-    setShowIcons(false);
+    navigate(path);
   };
 
   useEffect(() => {
@@ -39,14 +40,17 @@ function NavButton() {
   }, []);
 
   return (
-    <div className=" relative">
+    <div className="relative">
       {showIcons && (
-        <div className=" flex flex-col items-center ">
-          <button onClick={handleHomeClick} className="mb-2">
-            <Bars4Icon className="w-6 h-6 text-white rounded-full hover:border-2" />
+        <div className="flex flex-col items-center nav-menu" ref={menuRef}>
+          <button onClick={() => handleNavigation("/")} className="mb-2">
+            <Bars4Icon className="w-6 h-6 p-1 text-white rounded-full hover:border-2" />
           </button>
-          <button onClick={handleSettingsClick} className="mb-2">
-            <Cog6ToothIcon className="w-6 h-6 text-white rounded-full hover:border-2" />
+          <button
+            onClick={() => handleNavigation("/day-view/settings")}
+            className="mb-2"
+          >
+            <Cog6ToothIcon className="w-6 h-6 p-1 text-white rounded-full hover:border-2" />
           </button>
         </div>
       )}

--- a/frontend-web/src/components/NavButton.jsx
+++ b/frontend-web/src/components/NavButton.jsx
@@ -1,0 +1,65 @@
+import { useState, useRef, useEffect } from "react";
+import {
+  Bars2Icon,
+  Cog6ToothIcon,
+  Bars4Icon,
+} from "@heroicons/react/24/outline";
+import { useNavigate } from "react-router-dom";
+
+function NavButton() {
+  const [showIcons, setShowIcons] = useState(false);
+  const buttonRef = useRef(null);
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    setShowIcons(!showIcons);
+  };
+
+  const handleOutsideClick = (event) => {
+    if (buttonRef.current && !buttonRef.current.contains(event.target)) {
+      setShowIcons(false);
+    }
+  };
+
+  const handleHomeClick = () => {
+    navigate("/");
+    setShowIcons(false);
+  };
+
+  const handleSettingsClick = () => {
+    navigate("/settings");
+    setShowIcons(false);
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleOutsideClick);
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick);
+    };
+  }, []);
+
+  return (
+    <div className=" relative">
+      {showIcons && (
+        <div className=" flex flex-col items-center ">
+          <button onClick={handleHomeClick} className="mb-2">
+            <Bars4Icon className="w-6 h-6 text-white rounded-full hover:border-2" />
+          </button>
+          <button onClick={handleSettingsClick} className="mb-2">
+            <Cog6ToothIcon className="w-6 h-6 text-white rounded-full hover:border-2" />
+          </button>
+        </div>
+      )}
+
+      <button
+        ref={buttonRef}
+        onClick={handleClick}
+        className="flex items-center justify-center w-12 h-12 rounded-full shadow-lg focus:outline-none hover:border-2 text-white"
+      >
+        <Bars2Icon className="w-6 h-6 drop-shadow-[0_0_1px_white]" />
+      </button>
+    </div>
+  );
+}
+
+export default NavButton;

--- a/frontend-web/src/components/NavButton.jsx
+++ b/frontend-web/src/components/NavButton.jsx
@@ -42,15 +42,15 @@ function NavButton() {
   return (
     <div className="relative">
       {showIcons && (
-        <div className="flex flex-col items-center nav-menu" ref={menuRef}>
+        <div className="flex flex-col items-center nav-menu " ref={menuRef}>
           <button onClick={() => handleNavigation("/")} className="mb-2">
-            <Bars4Icon className="w-6 h-6 p-1 text-white rounded-full hover:border-2" />
+            <Bars4Icon className="w-7 h-7 p-1 text-white rounded-full hover:border-2 bg-gray-800" />
           </button>
           <button
             onClick={() => handleNavigation("/day-view/settings")}
             className="mb-2"
           >
-            <Cog6ToothIcon className="w-6 h-6 p-1 text-white rounded-full hover:border-2" />
+            <Cog6ToothIcon className="w-7 h-7 p-1 text-white rounded-full hover:border-2 bg-gray-800" />
           </button>
         </div>
       )}
@@ -58,7 +58,7 @@ function NavButton() {
       <button
         ref={buttonRef}
         onClick={handleClick}
-        className="flex items-center justify-center w-12 h-12 rounded-full shadow-lg focus:outline-none hover:border-2 text-white"
+        className="bg-gradient-to-tl from-black-300 to-gray-800 flex items-center justify-center w-12 h-12 rounded-full shadow-lg focus:outline-none hover:border-2 text-white"
       >
         <Bars2Icon className="w-6 h-6 drop-shadow-[0_0_1px_white]" />
       </button>

--- a/frontend-web/src/components/StyledSelect.jsx
+++ b/frontend-web/src/components/StyledSelect.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+const StyledSelect = ({ value, onChange, children, ...rest }) => {
+  return (
+    <select
+      value={value}
+      onChange={onChange}
+      className="
+          bg-gray-900
+          text-white
+          border
+          border-gray-600
+          rounded-full
+          p-3
+          mb-2
+          md:mb-0
+          md:mr-2
+          md:w-1/4
+          focus:bg-gray-700
+          focus:border-blue-500
+          focus:ring-1
+          focus:ring-blue-500
+          transition-colors
+          duration-200
+          placeholder-gray-400
+        "
+      {...rest}
+    >
+      {children}
+    </select>
+  );
+};
+
+export default StyledSelect;

--- a/frontend-web/src/components/StyledSubmit.jsx
+++ b/frontend-web/src/components/StyledSubmit.jsx
@@ -1,0 +1,32 @@
+const StyledInput = ({ type, value, onChange, placeholder, ...rest }) => {
+  return (
+    <input
+      type={type}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      className="
+          bg-gray-900
+          text-white
+          border
+          border-gray-600
+          rounded-full
+          p-3
+          mb-2
+          md:mb-0
+          md:mr-2
+          md:w-1/4
+          focus:bg-gray-700
+          focus:border-blue-500
+          focus:ring-1
+          focus:ring-blue-500
+          transition-colors
+          duration-200
+          placeholder-gray-400
+        "
+      {...rest}
+    />
+  );
+};
+
+export default StyledInput;

--- a/frontend-web/src/components/SubmitButton.jsx
+++ b/frontend-web/src/components/SubmitButton.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+const StyledSubmitButton = ({ children, ...rest }) => {
+  return (
+    <button
+      type="submit"
+      className="
+        bg-gradient-to-r from-blue-500 to-blue-600
+        text-white
+        font-medium
+        py-3 px-6
+        rounded-full
+        shadow-lg
+        hover:shadow-xl
+        hover:from-blue-600 hover:to-blue-700
+        active:scale-95
+        active:shadow-inner
+        transition-all
+        duration-200
+        focus:outline-none
+        focus:ring-2 focus:ring-blue-400
+        focus:ring-offset-2 focus:ring-offset-black
+      "
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default StyledSubmitButton;

--- a/frontend-web/src/routes/BarSettings.jsx
+++ b/frontend-web/src/routes/BarSettings.jsx
@@ -1,23 +1,16 @@
 import { useState } from "react";
 import TimePicker from "../components/TimePicker";
 import { XMarkIcon, ArrowRightCircleIcon } from "@heroicons/react/24/solid";
+import { useNavigate } from "react-router-dom";
 
 const Settings = () => {
+  const navigate = useNavigate();
   const [dayEndHourSetting, dayEndHourSettingValue] = useState(
     localStorage.getItem("dayEndHourSetting") || "11:59 PM"
   );
-  const handleEndSave = (time) => {
-    localStorage.setItem("dayEndHourSetting", time);
-    console.log("update end ", localStorage.getItem("dayEndHourSetting"));
-  };
-
   const [dayStartHourSetting, dayStartHourSettingValue] = useState(
     localStorage.getItem("dayStartHourSetting") || "12:00 AM"
   );
-  const handleStartSave = (time) => {
-    localStorage.setItem("dayStartHourSetting", time);
-    console.log("update start ", localStorage.getItem("dayStartHourSetting"));
-  };
 
   return (
     <div className="bg-[#f2f5f4] bg-cover bg-center w-screen min-h-screen m-0 flex flex-col items-start pt-10 pl-1 sm:pt-12 sm:pl-20 px-4 sm:px-20">
@@ -25,7 +18,7 @@ const Settings = () => {
         Settings
       </div>
       <button
-        onClick={() => (window.location.href = "/")}
+        onClick={() => navigate(-1)}
         className="fixed top-7 right-4 p-3 text-white rounded-full rounded-full shadow-lg focus:outline-none hover:border-2"
       >
         <XMarkIcon className="text-gray-700 h-6 w-6" />
@@ -41,14 +34,18 @@ const Settings = () => {
           </label>
           <TimePicker
             defaultTime={dayStartHourSetting}
-            onTimeSelect={(time) => handleStartSave(time)}
+            onTimeSelect={(time) =>
+              localStorage.setItem("dayStartHourSetting", time)
+            }
           />
           <label className="block text-gray-600 sm:text-lg font-semibold mb-2">
             End of Day
           </label>
           <TimePicker
             defaultTime={dayEndHourSetting}
-            onTimeSelect={(time) => handleEndSave(time)}
+            onTimeSelect={(time) =>
+              localStorage.setItem("dayEndHourSetting", time)
+            }
           />
         </div>
       </div>

--- a/frontend-web/src/routes/CategorySettings.jsx
+++ b/frontend-web/src/routes/CategorySettings.jsx
@@ -1,0 +1,124 @@
+import React, { useState, useEffect } from "react";
+import { XMarkIcon } from "@heroicons/react/24/solid";
+import { MinusCircleIcon } from "@heroicons/react/24/solid";
+
+import { useNavigate } from "react-router-dom";
+
+const CategorySettings = () => {
+  const navigate = useNavigate();
+  const [categories, setCategories] = useState([]);
+  const [newCategory, setNewCategory] = useState("");
+  const [timeAmount, setTimeAmount] = useState("");
+  const [timeUnit, setTimeUnit] = useState("minutes"); // Default to minutes
+
+  useEffect(() => {
+    // Load categories from localStorage or default
+    const storedCategories = localStorage.getItem("userCategories");
+    if (storedCategories) {
+      setCategories(JSON.parse(storedCategories));
+    }
+  }, []);
+
+  useEffect(() => {
+    // Save categories to localStorage whenever it changes
+    localStorage.setItem("userCategories", JSON.stringify(categories));
+  }, [categories]);
+
+  const addCategory = (e) => {
+    e.preventDefault();
+    if (newCategory.trim() !== "" && timeAmount.trim() !== "") {
+      setCategories([
+        ...categories,
+        {
+          category: newCategory.trim(),
+          time: timeAmount.trim(),
+          unit: timeUnit,
+        },
+      ]);
+      setNewCategory("");
+      setTimeAmount("");
+    }
+  };
+
+  const removeCategory = (categoryToRemove) => {
+    setCategories(
+      categories.filter((cat) => cat.category !== categoryToRemove)
+    );
+  };
+
+  return (
+    <div className="bg-[#000000] bg-cover bg-center w-screen min-h-screen m-0 flex flex-col items-start pt-10 pl-1 sm:pt-12 sm:pl-20 px-4 sm:px-20">
+      <div className="text-white pl-8 text-2xl sm:text-2xl font-bold ">
+        Settings
+      </div>
+      <button
+        onClick={() => navigate(-1)}
+        className="fixed top-7 right-4 p-3 text-white rounded-full rounded-full shadow-lg focus:outline-none hover:border-2"
+      >
+        <XMarkIcon className="text-gray-700 h-6 w-6" />
+      </button>
+
+      <div className="pt-3 px-4 w-full">
+        <hr className="border-t border-gray-300 my-4" />
+      </div>
+
+      <div className="flex flex-col sm:pl-20 mt-15 ">
+        <h2 className="text-2xl text-white font-semibold mb-4">Categories</h2>
+
+        <ul className="mb-4">
+          {categories.map((item) => (
+            <li
+              key={item.category}
+              className="flex text-white items-center justify-between py-2 border-b border-gray-200"
+            >
+              {item.category} - {item.time} {item.unit}
+              <button
+                aria-label="Remove Category"
+                onClick={() => removeCategory(item.category)}
+                className="text-white hover:text-red-700 font-bold"
+              >
+                <MinusCircleIcon className="text-gray-700 h-6 w-6 hover:border-2 rounded-full hover:outline-white" />
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <form onSubmit={addCategory} className="flex items-center">
+          <input
+            type="text"
+            value={newCategory}
+            onChange={(e) => setNewCategory(e.target.value)}
+            placeholder="Add Category"
+            className="text-white border border-gray-300 rounded-md p-2 mr-2 flex-grow"
+            required
+          />
+          <input
+            type="text"
+            value={timeAmount}
+            onChange={(e) => setTimeAmount(e.target.value)}
+            placeholder="Time Amount"
+            className="text-white border border-gray-300 rounded-md p-2 mr-2 w-1/4"
+            required
+          />
+          <select
+            value={timeUnit}
+            onChange={(e) => setTimeUnit(e.target.value)}
+            className="text-white border border-gray-300 rounded-md p-2 mr-2"
+          >
+            <option value="minutes">Minutes</option>
+            <option value="hours">Hours</option>
+          </select>
+          <button
+            type="submit"
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          >
+            Add
+          </button>
+        </form>
+        <div className="grid grid-cols-2 items-center gap-2 sm:gap-4 pl-1"></div>
+      </div>
+    </div>
+  );
+};
+
+export default CategorySettings;

--- a/frontend-web/src/routes/CategorySettings.jsx
+++ b/frontend-web/src/routes/CategorySettings.jsx
@@ -133,7 +133,7 @@ const CategorySettings = () => {
               grid-cols-[minmax(0,1fr)_auto_auto_auto] 
               text-white
               items-center // used for vertical centering
-              py-5 border-b border-gray-300
+              py-5 border-b border-gray-500
               gap-2
               "
             >

--- a/frontend-web/src/routes/CategorySettings.jsx
+++ b/frontend-web/src/routes/CategorySettings.jsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from "react";
-import { XMarkIcon } from "@heroicons/react/24/solid";
+import React, { useState, useEffect, useRef } from "react";
+import { ChevronRightIcon } from "@heroicons/react/24/solid";
 import { MinusCircleIcon } from "@heroicons/react/24/solid";
-
+import StyledSubmitButton from "../components/SubmitButton";
+import StyledSelect from "../components/StyledSelect";
+import StyledInput from "../components/StyledSubmit";
 import { useNavigate } from "react-router-dom";
 
 const CategorySettings = () => {
@@ -9,10 +11,50 @@ const CategorySettings = () => {
   const [categories, setCategories] = useState([]);
   const [newCategory, setNewCategory] = useState("");
   const [timeAmount, setTimeAmount] = useState("");
-  const [timeUnit, setTimeUnit] = useState("minutes"); // Default to minutes
+  const [timeUnit, setTimeUnit] = useState("minutes");
+
+  const [editingIndex, setEditingIndex] = useState(null);
+  const [editedText, setEditedText] = useState("");
+  const editedTextRef = useRef(null);
+
+  const handleTimeClick = (index, currentText) => {
+    setEditingIndex(index);
+    setEditedText(currentText);
+    // delay to allow render
+    setTimeout(() => {
+      editedTextRef.current?.focus();
+    }, 0);
+  };
+
+  const handleTextChange = (e) => {
+    setEditedText(e.target.value);
+  };
+
+  const handleBlur = (index) => {
+    if (editedText.trim() === "") {
+      setEditingIndex(null);
+      return;
+    }
+
+    const updatedEvents = categories.map((event, i) => {
+      if (i === index) {
+        return { ...event, time: editedText };
+      }
+      return event;
+    });
+    setCategories(updatedEvents);
+    setEditingIndex(null);
+  };
+
+  const handleKeyDown = (e, index) => {
+    if (e.key === "Enter") {
+      handleBlur(index);
+    } else if (e.key === "Escape") {
+      setEditingIndex(null);
+    }
+  };
 
   useEffect(() => {
-    // Load categories from localStorage or default
     const storedCategories = localStorage.getItem("userCategories");
     if (storedCategories) {
       setCategories(JSON.parse(storedCategories));
@@ -20,7 +62,6 @@ const CategorySettings = () => {
   }, []);
 
   useEffect(() => {
-    // Save categories to localStorage whenever it changes
     localStorage.setItem("userCategories", JSON.stringify(categories));
   }, [categories]);
 
@@ -47,75 +88,147 @@ const CategorySettings = () => {
   };
 
   return (
-    <div className="bg-[#000000] bg-cover bg-center w-screen min-h-screen m-0 flex flex-col items-start pt-10 pl-1 sm:pt-12 sm:pl-20 px-4 sm:px-20">
-      <div className="text-white pl-8 text-2xl sm:text-2xl font-bold ">
-        Settings
+    <div
+      className="bg-[#000000] bg-cover bg-center 
+    w-screen min-h-screen m-0 flex flex-col
+    pt-10 pl-1 px-4
+    sm:pt-12  sm:px-20"
+    >
+      {/* Header */}
+      <div className="flex flex-row items-center justify-between w-full pr-2">
+        <div className="text-white pl-8 text-2xl sm:text-2xl  py-4 font-sans">
+          Daily Settings
+        </div>
+        <button
+          onClick={() => navigate(-1)}
+          className="p-2
+          text-white rounded-full rounded-full
+          outline-1 
+          outline-gray-400
+          shadow-lg
+          bg-gray-600
+        hover:bg-gradient-to-r hover:from-gray-400 hover:to-gray-600
+          hover:shadow-xl
+          hover:ring-1
+          hover:ring-gray-600
+          "
+        >
+          <ChevronRightIcon
+            className="text-gray-00 h-6 w-6
+          hover:shadow-xl "
+          />
+        </button>
       </div>
-      <button
-        onClick={() => navigate(-1)}
-        className="fixed top-7 right-4 p-3 text-white rounded-full rounded-full shadow-lg focus:outline-none hover:border-2"
-      >
-        <XMarkIcon className="text-gray-700 h-6 w-6" />
-      </button>
-
       <div className="pt-3 px-4 w-full">
         <hr className="border-t border-gray-300 my-4" />
       </div>
 
-      <div className="flex flex-col sm:pl-20 mt-15 ">
-        <h2 className="text-2xl text-white font-semibold mb-4">Categories</h2>
-
-        <ul className="mb-4">
-          {categories.map((item) => (
+      {/* content */}
+      <div className="flex flex-col pl-4 mt-5 items-center">
+        <ul className="pt-3 px-4 mb-4 w-full">
+          {categories.map((item, index) => (
             <li
-              key={item.category}
-              className="flex text-white items-center justify-between py-2 border-b border-gray-200"
+              key={index}
+              className="grid
+              grid-cols-[minmax(0,1fr)_auto_auto_auto] 
+              text-white
+              items-center // used for vertical centering
+              py-5 border-b border-gray-300
+              gap-2
+              "
             >
-              {item.category} - {item.time} {item.unit}
+              <span
+                className="
+  py-1
+  text-gray-200
+  pr-5
+  
+  "
+              >
+                {item.category}
+              </span>
+              {editingIndex === index ? (
+                <input
+                  ref={editedTextRef}
+                  type="text"
+                  value={editedText}
+                  onChange={handleTextChange}
+                  onBlur={() => handleBlur(index)}
+                  onKeyDown={(e) => handleKeyDown(e, index)}
+                  className="bg-gray-700 rounded-full px-2 py-1 mr-1 outline-none focus:ring-2 focus:ring-blue-500"
+                  style={{ width: `${Math.max(editedText.length * 2, 80)}px` }}
+                />
+              ) : (
+                <div
+                  onClick={() => handleTimeClick(index, item.time)}
+                  className="bg-gray-800 rounded-full px-2 py-1 mr-2 mb-1 cursor-pointer hover:bg-gray-700 transition-colors"
+                  style={{ width: `${Math.max(item.time.length * 8, 80)}px` }}
+                >
+                  {item.time}
+                </div>
+              )}
+              <span className="sm:px-4 px-1">
+                {item.unit === "minutes" ? "min" : "hr"}
+              </span>
               <button
                 aria-label="Remove Category"
                 onClick={() => removeCategory(item.category)}
-                className="text-white hover:text-red-700 font-bold"
+                className="bg-gradient-to-r from-gray-300 to-blue-300
+        text-white
+        font-medium
+        rounded-full
+        shadow-lg
+        hover:shadow-xl
+        hover:from-yellow-600 hover:to-blue-700
+        active:scale-95
+        active:shadow-inner
+        transition-all
+        duration-200
+        focus:outline-none
+        focus:ring-2 focus:ring-blue-400
+        focus:ring-offset-2 focus:ring-offset-black
+        mb-1"
               >
-                <MinusCircleIcon className="text-gray-700 h-6 w-6 hover:border-2 rounded-full hover:outline-white" />
+                <MinusCircleIcon
+                  className="
+                text-gray-700
+                h-6 w-6
+                hover:border-2
+                rounded-full
+                hover:outline-white"
+                />
               </button>
             </li>
           ))}
         </ul>
 
-        <form onSubmit={addCategory} className="flex items-center">
-          <input
+        <form
+          onSubmit={addCategory}
+          className="mt-2 flex flex-col md:flex-row gap-1"
+        >
+          <StyledInput
             type="text"
             value={newCategory}
             onChange={(e) => setNewCategory(e.target.value)}
             placeholder="Add Category"
-            className="text-white border border-gray-300 rounded-md p-2 mr-2 flex-grow"
             required
           />
-          <input
-            type="text"
+          <StyledInput
+            type="number"
             value={timeAmount}
             onChange={(e) => setTimeAmount(e.target.value)}
             placeholder="Time Amount"
-            className="text-white border border-gray-300 rounded-md p-2 mr-2 w-1/4"
             required
           />
-          <select
+          <StyledSelect
             value={timeUnit}
             onChange={(e) => setTimeUnit(e.target.value)}
-            className="text-white border border-gray-300 rounded-md p-2 mr-2"
           >
             <option value="minutes">Minutes</option>
             <option value="hours">Hours</option>
-          </select>
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-          >
-            Add
-          </button>
+          </StyledSelect>
+          <StyledSubmitButton>Add</StyledSubmitButton>
         </form>
-        <div className="grid grid-cols-2 items-center gap-2 sm:gap-4 pl-1"></div>
       </div>
     </div>
   );

--- a/frontend-web/src/routes/Day.jsx
+++ b/frontend-web/src/routes/Day.jsx
@@ -70,34 +70,6 @@ const Day = () => {
   const [editedText, setEditedText] = useState("");
   const editedTextRef = useRef(null);
 
-  // TODO : replace with nosql call
-  const handleSync = async () => {
-    try {
-      const authCheckResponse = await fetch(
-        import.meta.env.VITE_CLOUDFRONT_AUTH_CHECK,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          credentials: "include",
-        }
-      );
-      if (authCheckResponse.status === 200) {
-        // TODO: remove dummy data
-
-        setCalendarEvents([
-          { Category: "Cat1", Event: "EventA", Time: 0 },
-          { Category: "Cat2", Event: "EventA", Time: 15 },
-          { Category: "Cat3", Event: "EventA", Time: 10 },
-          { Category: "Cat3", Event: "EventA", Time: 10 },
-        ]);
-      }
-    } catch (error) {
-      console.error("Sync failed:", error);
-    }
-  };
-
   const handleCategoryClick = (index, currentText) => {
     setEditingIndex(index);
     setEditedText(currentText);
@@ -133,6 +105,34 @@ const Day = () => {
       handleBlur(index);
     } else if (e.key === "Escape") {
       setEditingIndex(null);
+    }
+  };
+
+  // TODO : replace with nosql call
+  const handleSync = async () => {
+    try {
+      const authCheckResponse = await fetch(
+        import.meta.env.VITE_CLOUDFRONT_AUTH_CHECK,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+        }
+      );
+      if (authCheckResponse.status === 200) {
+        // TODO: remove dummy data
+
+        setCalendarEvents([
+          { Category: "Cat1", Event: "EventA", Time: 0 },
+          { Category: "Cat2", Event: "EventA", Time: 15 },
+          { Category: "Cat3", Event: "EventA", Time: 10 },
+          { Category: "Cat3", Event: "EventA", Time: 10 },
+        ]);
+      }
+    } catch (error) {
+      console.error("Sync failed:", error);
     }
   };
 
@@ -224,11 +224,8 @@ const Day = () => {
   const currentDate = new Date();
   const day = currentDate.getDate();
   const month = currentDate.toLocaleDateString("en-US", { month: "long" });
-  // .toUpperCase();
   const weekday = currentDate.toLocaleDateString("en-US", { weekday: "long" });
   const year = currentDate.toLocaleDateString("en-US", { year: "numeric" });
-
-  // .toCase();
 
   return (
     <div
@@ -307,7 +304,7 @@ const Day = () => {
         </div>
       </div>
 
-      <div className=" fixed top-4 sm:bottom-2  md:top-auto right-4 p-1 rounded-full ">
+      <div className=" fixed top-4 sm:bottom-4  md:top-auto right-4 p-1 rounded-full ">
         <NavButton />
       </div>
     </div>

--- a/frontend-web/src/routes/Day.jsx
+++ b/frontend-web/src/routes/Day.jsx
@@ -1,24 +1,52 @@
 import { useState, useRef, useEffect } from "react";
 import Chart from "chart.js/auto";
 import { ArrowPathRoundedSquareIcon } from "@heroicons/react/24/outline";
+import { useAuthContext } from "../hooks/useAuth.jsx";
+import { Bars2Icon } from "@heroicons/react/24/solid";
+import NavButton from "../components/NavButton.jsx";
 
 const Day = () => {
   const chartRef = useRef(null);
   const chartInstance = useRef(null);
   const [calendarEvents, setCalendarEvents] = useState([
-    ["Category1", "Event2"],
-    ["Category3", "Event4"],
-    ["Category5", "Event6"],
+    ["Cat1", "EventA", 60],
+    ["Cat2", "EventB", 20],
+    ["Cat3", "EventC", 10],
+    ["Cat4", "EventD", 10],
   ]);
 
   const [editingIndex, setEditingIndex] = useState(null);
   const [editedText, setEditedText] = useState("");
   const editedTextRef = useRef(null);
 
+  const handleSync = async () => {
+    try {
+      const authCheckResponse = await fetch(
+        import.meta.env.VITE_CLOUDFRONT_AUTH_CHECK,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+        }
+      );
+      if (authCheckResponse.status === 200) {
+        setCalendarEvents([
+          ["Category1", "Event2"],
+          ["Category3", "Event4"],
+          ["Category5", "Event6"],
+        ]);
+      }
+    } catch (error) {
+      console.error("Sync failed:", error);
+    }
+  };
+
   const handleCategoryClick = (index, currentText) => {
     setEditingIndex(index);
     setEditedText(currentText);
-    // small delay to allow render
+    // delay to allow render
     setTimeout(() => {
       editedTextRef.current?.focus();
     }, 0);
@@ -51,6 +79,7 @@ const Day = () => {
       setEditingIndex(null);
     }
   };
+
   useEffect(() => {
     const dailyMotivators = {
       Cat1: 0,
@@ -74,13 +103,13 @@ const Day = () => {
           {
             label: "",
             data: motivatorValues,
-            backgroundColor: "rgba(255, 99, 132, 0.2)", // Keep fill color
+            backgroundColor: "rgba(255, 99, 132, 0.2)",
             borderColor: "rgb(255, 99, 132)",
             pointBackgroundColor: "rgb(255, 99, 132)",
             pointBorderColor: "#fff",
             pointHoverBackgroundColor: "#fff",
             pointHoverBorderColor: "rgb(255, 99, 132)",
-            fill: true, // Explicitly enable fill (default behavior)
+            fill: true,
           },
         ],
       },
@@ -95,7 +124,7 @@ const Day = () => {
             // radar chart scales under 'r'
             angleLines: {
               display: true,
-              color: "rgba(255, 255, 255, 0.9)", // Semi-transparent white
+              color: "rgba(255, 255, 255, 0.9)",
             },
             suggestedMin: 0,
             suggestedMax: 1,
@@ -179,6 +208,10 @@ const Day = () => {
             </div>
           ))}
         </div>
+      </div>
+
+      <div className="fixed bottom-4 right-4 p-3 text-white rounded-full ">
+        <NavButton />
       </div>
     </div>
   );

--- a/frontend-web/src/routes/Day.jsx
+++ b/frontend-web/src/routes/Day.jsx
@@ -1,24 +1,76 @@
 import { useState, useRef, useEffect } from "react";
 import Chart from "chart.js/auto";
 import { ArrowPathRoundedSquareIcon } from "@heroicons/react/24/outline";
-import { useAuthContext } from "../hooks/useAuth.jsx";
-import { Bars2Icon } from "@heroicons/react/24/solid";
 import NavButton from "../components/NavButton.jsx";
+
+function calculateCategoryPercentages(todayEvents, todayCategories) {
+  const categoryTotals = {};
+  const categoryPercentages = [];
+
+  todayCategories.forEach((category) => {
+    categoryTotals[category.Category] = 0;
+  });
+
+  // sum
+  todayEvents.forEach((event) => {
+    if (categoryTotals.hasOwnProperty(event.Category)) {
+      categoryTotals[event.Category] += event.Time;
+    }
+  });
+
+  // percentage
+  todayCategories.forEach((category) => {
+    const totalTime = categoryTotals[category.Category] || 0;
+    const categoryTimeLimit = category.Time;
+    const percentage = Math.min((totalTime / categoryTimeLimit) * 100, 100);
+    categoryPercentages[category.Category] = percentage;
+  });
+
+  return categoryPercentages;
+}
 
 const Day = () => {
   const chartRef = useRef(null);
   const chartInstance = useRef(null);
+  // TODO: remove dummy data
   const [calendarEvents, setCalendarEvents] = useState([
-    ["Cat1", "EventA", 60],
-    ["Cat2", "EventB", 20],
-    ["Cat3", "EventC", 10],
-    ["Cat4", "EventD", 10],
+    {
+      Category: "Cat1",
+      Event: "Extra long event with many things happening3",
+      Time: 0,
+    },
+    {
+      Category: "Cat2",
+      Event: "Extra long event with many things happening",
+      Time: 15,
+    },
+    {
+      Category: "Cat3",
+      Event: "Extra long event with many things happening2",
+      Time: 10,
+    },
+    {
+      Category: "Cat3",
+      Event: "Extra long event with many things happening4",
+      Time: 10,
+    },
+    {
+      Category: "Cat3",
+      Event: "Extra long event with many things happening45",
+      Time: 10,
+    },
+    {
+      Category: "Cat3",
+      Event: "Extra long event with many things happening456",
+      Time: 10,
+    },
   ]);
 
   const [editingIndex, setEditingIndex] = useState(null);
   const [editedText, setEditedText] = useState("");
   const editedTextRef = useRef(null);
 
+  // TODO : replace with nosql call
   const handleSync = async () => {
     try {
       const authCheckResponse = await fetch(
@@ -32,10 +84,13 @@ const Day = () => {
         }
       );
       if (authCheckResponse.status === 200) {
+        // TODO: remove dummy data
+
         setCalendarEvents([
-          ["Category1", "Event2"],
-          ["Category3", "Event4"],
-          ["Category5", "Event6"],
+          { Category: "Cat1", Event: "EventA", Time: 0 },
+          { Category: "Cat2", Event: "EventA", Time: 15 },
+          { Category: "Cat3", Event: "EventA", Time: 10 },
+          { Category: "Cat3", Event: "EventA", Time: 10 },
         ]);
       }
     } catch (error) {
@@ -64,12 +119,13 @@ const Day = () => {
 
     const updatedEvents = calendarEvents.map((event, i) => {
       if (i === index) {
-        return [editedText, event[1]];
+        return { ...event, Category: editedText };
       }
       return event;
     });
     setCalendarEvents(updatedEvents);
     setEditingIndex(null);
+    renderChart(updatedEvents);
   };
 
   const handleKeyDown = (e, index) => {
@@ -80,15 +136,19 @@ const Day = () => {
     }
   };
 
-  useEffect(() => {
-    const dailyMotivators = {
-      Cat1: 0,
-      Cat2: 1,
-      Cat3: 1,
-      Cat4: 0,
-    };
-    let motivatorKeys = Object.keys(dailyMotivators);
-    let motivatorValues = Object.values(dailyMotivators);
+  // chart
+  const renderChart = (events) => {
+    // TODO: remove dummy data
+
+    let todayCategories = [
+      { Category: "Cat1", Time: 60 },
+      { Category: "Cat2", Time: 20 },
+      { Category: "Cat3", Time: 60 },
+      { Category: "Cat4", Time: 20 },
+    ];
+    let todayResult = calculateCategoryPercentages(events, todayCategories);
+    let categoryKeys = Object.keys(todayResult);
+    let categoryValues = Object.values(todayResult);
 
     if (chartInstance.current) {
       chartInstance.current.destroy();
@@ -98,11 +158,11 @@ const Day = () => {
     chartInstance.current = new Chart(ctx, {
       type: "radar",
       data: {
-        labels: motivatorKeys,
+        labels: categoryKeys,
         datasets: [
           {
             label: "",
-            data: motivatorValues,
+            data: categoryValues,
             backgroundColor: "rgba(255, 99, 132, 0.2)",
             borderColor: "rgb(255, 99, 132)",
             pointBackgroundColor: "rgb(255, 99, 132)",
@@ -127,7 +187,7 @@ const Day = () => {
               color: "rgba(255, 255, 255, 0.9)",
             },
             suggestedMin: 0,
-            suggestedMax: 1,
+            suggestedMax: 100,
             ticks: {
               display: false,
               stepSize: 1,
@@ -149,39 +209,76 @@ const Day = () => {
         maintainAspectRatio: false,
       },
     });
+  };
+
+  useEffect(() => {
+    renderChart(calendarEvents);
 
     return () => {
       if (chartInstance.current) {
         chartInstance.current.destroy();
       }
     };
-  }, []);
+  }, [calendarEvents]);
+
+  const currentDate = new Date();
+  const day = currentDate.getDate();
+  const month = currentDate.toLocaleDateString("en-US", { month: "long" });
+  // .toUpperCase();
+  const weekday = currentDate.toLocaleDateString("en-US", { weekday: "long" });
+  const year = currentDate.toLocaleDateString("en-US", { year: "numeric" });
+
+  // .toCase();
 
   return (
-    <div className="bg-[#000000] bg-cover bg-center w-screen min-h-screen m-0 flex flex-col md:flex-row pt-10 pl-1 sm:pt-12 sm:pl-20 px-4 sm:px-20">
-      <div className="flex flex-col md:w-3/4 md:pr-4 items-start">
+    <div
+      className="bg-[#000000] 
+    /* Layout */
+    flex flex-col
+    w-screen min-h-screen m-0
+    md:flex-row
+    
+    /* Background */
+    bg-[#000000] bg-cover bg-center
+    
+    /* Spacing */
+    pt-5 pl-5 pr-5 px-4 pb-5
+    sm:pt-12 sm:pl-20 sm:px-20
+    
+    text-white"
+    >
+      <div className="flex flex-col md:w-3/4 md:pr-4 items-start ">
         {" "}
         {/* First column: graph, title */}
-        <div className="text-white text-2xl font-bold mb-4">
-          Day Events Chart
+        <div className="flex flex-row">
+          <div className="bg-gradient-to-tl from-blue-300 to-orange-100 rounded-full w-12 h-12 flex items-center justify-center text-2xl font-bold text-gray-800 mr-4">
+            {day}
+          </div>
+          <div className="text-l mb-2 pl-2">
+            {weekday}, {month} {year}
+          </div>
         </div>
         <div className="p-8 rounded-lg shadow-lg">
-          <canvas ref={chartRef} width="400" height="400" />
+          <canvas
+            ref={chartRef}
+            className="w-full h-80 sm:w-3/4 sm:h-96 md:w-2/3 md:h-96 lg:w-1/2 lg:h-96"
+          />
         </div>
       </div>
       {/* Second column: button and events */}
 
-      <div className="flex flex-col md:w-1/2 md:pl-4 md:mt-80">
+      <div className="flex flex-col  md:w-1/2 md:pl-4 md:mt-80">
         <div className="flex justify-end items-end">
           <button
-            onClick={() => (window.location.href = "/")}
-            className="p-3 text-white rounded-full shadow-lg focus:outline-none hover:border-2 flex items-center"
+            onClick={handleSync()}
+            className="bg-gradient-to-tl from-black-300 to-gray-800 p-3 rounded-full shadow-lg focus:outline-none hover:border-2 flex items-center"
           >
-            Sync Calendar Events
+            Sync Events
             <ArrowPathRoundedSquareIcon className="h-6 w-6 text-blue-500 ml-2" />
           </button>
         </div>
-        <div className="flex flex-col mt-4 space-y-2">
+        {/* events */}
+        <div className="flex flex-col flex-grow mt-2 space-y-2 p-1">
           {calendarEvents.map((event, index) => (
             <div key={index} className="flex items-center">
               {editingIndex === index ? (
@@ -192,25 +289,25 @@ const Day = () => {
                   onChange={handleTextChange}
                   onBlur={() => handleBlur(index)}
                   onKeyDown={(e) => handleKeyDown(e, index)}
-                  className="bg-gray-700 text-white rounded-full px-3 py-1 mr-2 outline-none focus:ring-2 focus:ring-blue-500"
+                  className="bg-gray-700 rounded-full px-3 py-1 mr-2 outline-none focus:ring-2 focus:ring-blue-500"
                   style={{ width: `${Math.max(editedText.length * 8, 80)}px` }}
                 />
               ) : (
                 <div
-                  onClick={() => handleCategoryClick(index, event[0])}
-                  className="bg-gray-800 text-white rounded-full px-3 py-1 mr-6 mb-1 cursor-pointer hover:bg-gray-700 transition-colors"
+                  onClick={() => handleCategoryClick(index, event.Category)}
+                  className="bg-gray-800 rounded-full px-3 py-1 mr-6 mb-1 cursor-pointer hover:bg-gray-700 transition-colors"
                 >
-                  {event[0] || "No Category"}
+                  {event.Category || "No Category"}
                 </div>
               )}
 
-              <span className="text-white">{event[1] || ""}</span>
+              <span>{event.Event || ""} </span>
             </div>
           ))}
         </div>
       </div>
 
-      <div className="fixed bottom-4 right-4 p-3 text-white rounded-full ">
+      <div className=" fixed top-4 sm:bottom-2  md:top-auto right-4 p-1 rounded-full ">
         <NavButton />
       </div>
     </div>

--- a/frontend-web/src/routes/Day.jsx
+++ b/frontend-web/src/routes/Day.jsx
@@ -72,7 +72,7 @@ const Day = () => {
         labels: motivatorKeys,
         datasets: [
           {
-            label: "Fulfillment",
+            label: "",
             data: motivatorValues,
             backgroundColor: "rgba(255, 99, 132, 0.2)", // Keep fill color
             borderColor: "rgb(255, 99, 132)",
@@ -85,6 +85,11 @@ const Day = () => {
         ],
       },
       options: {
+        plugins: {
+          legend: {
+            display: false,
+          },
+        },
         scales: {
           r: {
             // radar chart scales under 'r'
@@ -95,6 +100,7 @@ const Day = () => {
             suggestedMin: 0,
             suggestedMax: 1,
             ticks: {
+              display: false,
               stepSize: 1,
               color: "#FFFFFF",
               backdropColor: "transparent",
@@ -128,7 +134,7 @@ const Day = () => {
         {" "}
         {/* First column: graph, title */}
         <div className="text-white text-2xl font-bold mb-4">
-          Daily Events Chart
+          Day Events Chart
         </div>
         <div className="p-8 rounded-lg shadow-lg">
           <canvas ref={chartRef} width="400" height="400" />

--- a/frontend-web/src/routes/Day.jsx
+++ b/frontend-web/src/routes/Day.jsx
@@ -1,0 +1,181 @@
+import { useState, useRef, useEffect } from "react";
+import Chart from "chart.js/auto";
+import { ArrowPathRoundedSquareIcon } from "@heroicons/react/24/outline";
+
+const Day = () => {
+  const chartRef = useRef(null);
+  const chartInstance = useRef(null);
+  const [calendarEvents, setCalendarEvents] = useState([
+    ["Category1", "Event2"],
+    ["Category3", "Event4"],
+    ["Category5", "Event6"],
+  ]);
+
+  const [editingIndex, setEditingIndex] = useState(null);
+  const [editedText, setEditedText] = useState("");
+  const editedTextRef = useRef(null);
+
+  const handleCategoryClick = (index, currentText) => {
+    setEditingIndex(index);
+    setEditedText(currentText);
+    // small delay to allow render
+    setTimeout(() => {
+      editedTextRef.current?.focus();
+    }, 0);
+  };
+
+  const handleTextChange = (e) => {
+    setEditedText(e.target.value);
+  };
+
+  const handleBlur = (index) => {
+    if (editedText.trim() === "") {
+      setEditingIndex(null);
+      return;
+    }
+
+    const updatedEvents = calendarEvents.map((event, i) => {
+      if (i === index) {
+        return [editedText, event[1]];
+      }
+      return event;
+    });
+    setCalendarEvents(updatedEvents);
+    setEditingIndex(null);
+  };
+
+  const handleKeyDown = (e, index) => {
+    if (e.key === "Enter") {
+      handleBlur(index);
+    } else if (e.key === "Escape") {
+      setEditingIndex(null);
+    }
+  };
+  useEffect(() => {
+    const dailyMotivators = {
+      Cat1: 0,
+      Cat2: 1,
+      Cat3: 1,
+      Cat4: 0,
+    };
+    let motivatorKeys = Object.keys(dailyMotivators);
+    let motivatorValues = Object.values(dailyMotivators);
+
+    if (chartInstance.current) {
+      chartInstance.current.destroy();
+    }
+    const ctx = chartRef.current.getContext("2d");
+
+    chartInstance.current = new Chart(ctx, {
+      type: "radar",
+      data: {
+        labels: motivatorKeys,
+        datasets: [
+          {
+            label: "Fulfillment",
+            data: motivatorValues,
+            backgroundColor: "rgba(255, 99, 132, 0.2)", // Keep fill color
+            borderColor: "rgb(255, 99, 132)",
+            pointBackgroundColor: "rgb(255, 99, 132)",
+            pointBorderColor: "#fff",
+            pointHoverBackgroundColor: "#fff",
+            pointHoverBorderColor: "rgb(255, 99, 132)",
+            fill: true, // Explicitly enable fill (default behavior)
+          },
+        ],
+      },
+      options: {
+        scales: {
+          r: {
+            // radar chart scales under 'r'
+            angleLines: {
+              display: true,
+              color: "rgba(255, 255, 255, 0.9)", // Semi-transparent white
+            },
+            suggestedMin: 0,
+            suggestedMax: 1,
+            ticks: {
+              stepSize: 1,
+              color: "#FFFFFF",
+              backdropColor: "transparent",
+              showLabelBackdrop: false,
+            },
+            pointLabels: {
+              fontSize: 16,
+              color: "#FFFFFF",
+              backdropColor: "transparent",
+              font: {
+                backgroundColor: "transparent",
+              },
+            },
+          },
+        },
+        responsive: true,
+        maintainAspectRatio: false,
+      },
+    });
+
+    return () => {
+      if (chartInstance.current) {
+        chartInstance.current.destroy();
+      }
+    };
+  }, []);
+
+  return (
+    <div className="bg-[#000000] bg-cover bg-center w-screen min-h-screen m-0 flex flex-col md:flex-row pt-10 pl-1 sm:pt-12 sm:pl-20 px-4 sm:px-20">
+      <div className="flex flex-col md:w-3/4 md:pr-4 items-start">
+        {" "}
+        {/* First column: graph, title */}
+        <div className="text-white text-2xl font-bold mb-4">
+          Daily Events Chart
+        </div>
+        <div className="p-8 rounded-lg shadow-lg">
+          <canvas ref={chartRef} width="400" height="400" />
+        </div>
+      </div>
+      {/* Second column: button and events */}
+
+      <div className="flex flex-col md:w-1/2 md:pl-4 md:mt-80">
+        <div className="flex justify-end items-end">
+          <button
+            onClick={() => (window.location.href = "/")}
+            className="p-3 text-white rounded-full shadow-lg focus:outline-none hover:border-2 flex items-center"
+          >
+            Sync Calendar Events
+            <ArrowPathRoundedSquareIcon className="h-6 w-6 text-blue-500 ml-2" />
+          </button>
+        </div>
+        <div className="flex flex-col mt-4 space-y-2">
+          {calendarEvents.map((event, index) => (
+            <div key={index} className="flex items-center">
+              {editingIndex === index ? (
+                <input
+                  ref={editedTextRef}
+                  type="text"
+                  value={editedText}
+                  onChange={handleTextChange}
+                  onBlur={() => handleBlur(index)}
+                  onKeyDown={(e) => handleKeyDown(e, index)}
+                  className="bg-gray-700 text-white rounded-full px-3 py-1 mr-2 outline-none focus:ring-2 focus:ring-blue-500"
+                  style={{ width: `${Math.max(editedText.length * 8, 80)}px` }}
+                />
+              ) : (
+                <div
+                  onClick={() => handleCategoryClick(index, event[0])}
+                  className="bg-gray-800 text-white rounded-full px-3 py-1 mr-6 mb-1 cursor-pointer hover:bg-gray-700 transition-colors"
+                >
+                  {event[0] || "No Category"}
+                </div>
+              )}
+
+              <span className="text-white">{event[1] || ""}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Day;

--- a/frontend-web/src/routes/ProgressBar.jsx
+++ b/frontend-web/src/routes/ProgressBar.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import "./index-output.css"; // Import the CSS file
+import "../index-output.css"; // Import the CSS file
 import { Bars2Icon } from "@heroicons/react/24/solid";
 import { min } from "mathjs";
 

--- a/frontend-web/src/routes/ProgressBar.jsx
+++ b/frontend-web/src/routes/ProgressBar.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import "../index-output.css"; // Import the CSS file
+import "../index-output.css";
 import { Bars2Icon } from "@heroicons/react/24/solid";
 import { min } from "mathjs";
 


### PR DESCRIPTION
Routes for day view and day view settings without the api calls for fetching / syncing data
Created components for text input fields 
- day view route for visualizing radar chart of different categories
    - Chart js graph rendered on left with amounts from list of day's events on right, maximum of axes from the settings
    - Editable categories for events
- day view settings route for setting categories and time amounts
Also did a few minor cleanups on progress bar /settings, renamed & removed logging

testing:
categories added in daily settings
graph renders according to categories of events
