### PR TITLE
feat(categories) endoint & lambda for revisions - delete/add/update

### DIFF
--- a/backend/update-categories/index.js
+++ b/backend/update-categories/index.js
@@ -1,0 +1,185 @@
+const {
+  DynamoDBClient,
+  UpdateItemCommand,
+  DeleteItemCommand,
+  BatchWriteItemCommand,
+} = require("@aws-sdk/client-dynamodb");
+
+const corsheaders = {
+  "Access-Control-Allow-Methods": "POST",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Authorization, Origin, X-Amz-Date, X-Api-Key, X-Amz-Security-Token",
+  "Access-Control-Allow-Credentials": "true",
+  "Content-Type": "application/json",
+};
+
+const allowedOrigins = [
+  "https://year-progress-bar.com",
+  "https://year-progress-bar.com",
+];
+const client = new DynamoDBClient({ region: "us-west-1" });
+const tableName = "pb_categories";
+
+// Updates
+async function handleUpdates(updates) {
+  if (updates && updates.length > 0) {
+    const updatePromises = updates.map(async (item) => {
+      const { category_uid, time } = item;
+      const params = {
+        TableName: tableName,
+        Key: { category_uid: { S: category_uid } },
+        UpdateExpression: "SET #t = :time",
+        ExpressionAttributeNames: { "#t": "time" },
+        ExpressionAttributeValues: { ":time": { N: time.toString() } },
+        ReturnValues: "ALL_NEW",
+      };
+      const command = new UpdateItemCommand(params);
+      try {
+        const response = await client.send(command);
+        return response.Attributes;
+      } catch (error) {
+        console.error("Error updating item:", error);
+        return { error: error.message, item };
+      }
+    });
+    return Promise.all(updatePromises);
+  }
+  return [];
+}
+
+// Adds
+async function handleAdds(adds, userId) {
+  if (adds && adds.length > 0) {
+    const createdAt = new Date().toISOString().slice(0, 10); // 'YYYY-MM-DD'
+
+    const putRequests = adds.map((item) => {
+      console.log("log add", {
+        category_uid: { S: `${userId}:${item.category}` },
+        category: { S: item.category },
+        time: { N: item.time.toString() },
+        user_id: { S: userId },
+        created_at: { S: createdAt },
+      });
+      return {
+        PutRequest: {
+          Item: {
+            category_uid: { S: `${userId}:${item.category}` },
+            category: { S: item.category },
+            time: { N: item.time.toString() },
+            user_id: { S: userId },
+            created_at: { S: createdAt },
+          },
+        },
+      };
+    });
+
+    const batchWriteParams = {
+      RequestItems: {
+        [tableName]: putRequests,
+      },
+    };
+
+    try {
+      const response = await client.send(
+        new BatchWriteItemCommand(batchWriteParams)
+      );
+      return response; // Return any unprocessed
+    } catch (error) {
+      console.error("Error batch writing items:", error);
+      return { error: error.message };
+    }
+  }
+  return {};
+}
+
+// deletes
+async function handleDeletes(deletes) {
+  if (deletes && deletes.length > 0) {
+    const deletePromises = deletes.map(async (item) => {
+      console.log(item);
+      const { category_uid } = item;
+
+      const params = {
+        TableName: tableName,
+        Key: { category_uid: { S: category_uid } },
+      };
+
+      const command = new DeleteItemCommand(params);
+
+      try {
+        const response = await client.send(command);
+        return [];
+      } catch (error) {
+        console.error("Error deleting item:", error);
+        return { error: error.message, item };
+      }
+    });
+    return Promise.all(deletePromises);
+  }
+  return [];
+}
+
+exports.handler = async (event) => {
+  let accessControlAllowOrigin = allowedOrigins[0];
+  let origin = event.headers.origin;
+  if (allowedOrigins.includes(origin)) {
+    accessControlAllowOrigin = origin;
+  }
+  let body;
+
+  try {
+    let userId = event.headers["user-id"];
+    if (!userId) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ message: "Missing user-id" }),
+        headers: {
+          "Access-Control-Allow-Origin": accessControlAllowOrigin,
+          ...corsheaders,
+        },
+      };
+    }
+
+    if (event.body !== null && event.body !== undefined) {
+      body = JSON.parse(event.body);
+      console.log("body", body);
+    }
+    console.log(userId);
+    let updates = body && body.update ? body.update : [];
+    let deletes = body && body.delete ? body.delete : [];
+    let adds = body && body.add ? body.add : [];
+
+    console.log("updates", updates);
+    console.log("deletes", deletes);
+    console.log("adds", adds);
+
+    const updateResults = await handleUpdates(updates);
+    const addResults = await handleAdds(adds, userId);
+    const deleteResults = await handleDeletes(deletes);
+
+    console.log("updateResults", updateResults);
+    console.log("addResults", addResults);
+    console.log("deleteResults", deleteResults);
+
+    return {
+      statusCode: 200,
+      headers: {
+        "Access-Control-Allow-Origin": accessControlAllowOrigin,
+        ...corsheaders,
+      },
+      body: JSON.stringify({
+        message: "Operations processed",
+      }),
+    };
+  } catch (error) {
+    console.error("Error:", error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ message: "Internal Server Error" }),
+      headers: {
+        "Access-Control-Allow-Origin": accessControlAllowOrigin,
+        ...corsheaders,
+      },
+    };
+  }
+};

--- a/terraform/apigateway.tf
+++ b/terraform/apigateway.tf
@@ -826,8 +826,46 @@ resource "aws_api_gateway_integration_response" "categories_options_integration_
 
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
-    "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET'",
+    "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET,POST'",
     "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
+  }
+}
+
+
+### update categories
+resource "aws_api_gateway_method" "categories_post_method" {
+  rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
+  resource_id   = aws_api_gateway_resource.categories_api.id
+  http_method   = "POST"
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.login_token_gateway_authorizer.id
+}
+
+resource "aws_api_gateway_integration" "categories_post_lambda_integration" {
+  rest_api_id = aws_api_gateway_rest_api.user_data_api.id
+  resource_id = aws_api_gateway_method.categories_post_method.resource_id
+  http_method = aws_api_gateway_method.categories_post_method.http_method
+  type                    = "AWS_PROXY"
+  integration_http_method = "POST"
+  credentials             = null
+  request_parameters = {}
+  request_templates = {}
+  uri = aws_lambda_function.update_categories.invoke_arn
+  passthrough_behavior = "WHEN_NO_MATCH" 
+}
+
+resource "aws_api_gateway_method_response" "categories_post_response" {
+  rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
+  resource_id   = aws_api_gateway_method.categories_post_method.resource_id
+  http_method   = aws_api_gateway_method.categories_post_method.http_method
+  status_code   = "200"
+
+  response_parameters = {
+      "method.response.header.Access-Control-Allow-Origin": true,
+      "method.response.header.Access-Control-Allow-Headers": true,
+      "method.response.header.Access-Control-Allow-Methods": true,
+      "method.response.header.Access-Control-Allow-Credentials": true,
+
   }
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -405,3 +405,34 @@ resource "aws_lambda_permission" "allow_apigateway_get_categories" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "arn:aws:execute-api:us-west-1:${data.aws_caller_identity.current.account_id}:${var.api_id}/*/GET/categories"
 }
+
+#### update categories
+resource "aws_s3_bucket_object" "update_categories" {
+  bucket = aws_s3_bucket.pbars_lambdas_bucket.bucket
+  source = "../backend/update-categories/update-categories.zip"
+  key    = "update-categories.zip"
+  content_type  = "application/zip"
+}
+
+resource "aws_lambda_function" "update_categories" {
+  function_name = "node-update-categories"
+  s3_bucket     = aws_s3_bucket_object.update_categories.bucket
+  s3_key        = aws_s3_bucket_object.update_categories.key
+
+  handler = "index.handler"
+  runtime = "nodejs22.x"  
+  depends_on = [aws_s3_bucket_object.update_categories]
+
+
+  role = aws_iam_role.lambda_execution_role.arn
+  timeout = 100
+  memory_size = 128
+}
+
+resource "aws_lambda_permission" "allow_apigateway_update_categories" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.update_categories.arn
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "arn:aws:execute-api:us-west-1:${data.aws_caller_identity.current.account_id}:${var.api_id}/*/POST/categories"
+}
+


### PR DESCRIPTION
New POST endpoint at `/categories` for performing bulk adds, updates, deletes for categories for making changes on the categories settings page. Settings give option to update time for categories, create new ones, and delete
Testing:
- Fetching api endpoint /categories POST with body containing optional fields `{update:[category_uid:], add:[category:,time:], delete:[category_uid:]}` returns 200 for properly handled records
- Dynamodb is updated according to api calls - delete, update, add