### PR TITLE
Day get categories on load

### DIFF
--- a/frontend-web/src/routes/CategorySettings.jsx
+++ b/frontend-web/src/routes/CategorySettings.jsx
@@ -38,7 +38,6 @@ const CategorySettings = () => {
           credentials: "include",
         }
       );
-      console.log(categoryResponse);
       if (categoryResponse.status === 200) {
         const responseData = await categoryResponse.json();
         const formattedCategories = responseData.categories.map((item) => ({
@@ -92,12 +91,6 @@ const CategorySettings = () => {
             const newRemainderMinutes = parseInt(value);
             newMinutes = cat.totalHours * 60 + newRemainderMinutes;
           }
-          console.log("updating", {
-            ...cat,
-            minutes: newMinutes,
-            totalHours: Math.floor(newMinutes / 60),
-            remainderMinutes: newMinutes % 60,
-          });
 
           return {
             ...cat,
@@ -109,7 +102,6 @@ const CategorySettings = () => {
         return cat;
       });
       setCategories(updatedCategories);
-      console.log("upodated numbers", categories);
       setEditingCell({ index: null, field: null });
     }
   };
@@ -145,7 +137,6 @@ const CategorySettings = () => {
         remainderMinutes: minutes % 60,
       };
       setCategories([...categories, parsedCategory]);
-      console.log(categories);
       setNewCategory("");
       setTimeAmount("");
     }

--- a/frontend-web/src/routes/Day.jsx
+++ b/frontend-web/src/routes/Day.jsx
@@ -35,7 +35,6 @@ const Day = () => {
           credentials: "include",
         }
       );
-      console.log(eventResponse);
       if (eventResponse.status === 200) {
         const responseData = await eventResponse.json();
         setCalendarEvents(responseData.events);


### PR DESCRIPTION
Update:
Day view dummy data was replaced to pull up user categories. Category edits on events are automatically title cased. Categories in graphs are title cased.
Day view settings also pulls up categories. Day view settings ui was updated to show separate editable hours  totalHours and minutes remainderMinutes fields and fills in units with minutes field.

Testing:
- Day view pulls up saved user categories
- Day view settings pulls up saved user categories