### PR TITLE
feat(day-view) update event categories

### DIFF
--- a/backend/get-calendar-events/index.js
+++ b/backend/get-calendar-events/index.js
@@ -9,8 +9,21 @@ const corsheaders = {
 };
 const { unmarshall } = require("@aws-sdk/util-dynamodb");
 
-const allowedOrigins = ["https://localhost:5173", "https://localhost:5173"];
+const allowedOrigins = [
+  "https://year-progress-bar.com",
+  "https://localhost:5173",
+];
 const dynamodb = new DynamoDBClient({ region: "us-west-1" });
+
+function titleCase(str) {
+  return str
+    .toLowerCase()
+    .split(" ")
+    .map(function (word) {
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(" ");
+}
 
 exports.handler = async (event) => {
   let accessControlAllowOrigin = allowedOrigins[0];
@@ -53,12 +66,13 @@ exports.handler = async (event) => {
     // Formatting
     const formattedEvents = result.Items.map((item) => ({
       event_uid: item.event_uid.S,
-      category: "Placeholder",
+      category: item.category?.S ? titleCase(item.category.S) : "Placeholder",
       start_date: item.event_startdate.S,
       start_time: item.event_starttime.S,
       event_name: item.event_name.S,
       minutes: Number(item.minutes.N),
     }));
+    console.log("Returning Formatted Events:", formattedEvents);
 
     return {
       statusCode: 200,

--- a/backend/patch-calendar-events/index.js
+++ b/backend/patch-calendar-events/index.js
@@ -69,7 +69,7 @@ exports.handler = async (event) => {
       };
     }
 
-    let event_uid = event.pathParameters.event_uid;
+    let event_uid = decodeURIComponent(event.pathParameters.event_uid);
     if (!event_uid) {
       return {
         statusCode: 400,

--- a/frontend-web/src/routes/Day.jsx
+++ b/frontend-web/src/routes/Day.jsx
@@ -14,6 +14,7 @@ const Day = () => {
   const weekday = currentDate.toLocaleDateString("en-US", { weekday: "long" });
   const year = currentDate.toLocaleDateString("en-US", { year: "numeric" });
 
+  // Refresh After Settings Category Update
   useEffect(() => {
     const refreshDataWithDelay = async () => {
       if (location?.state?.refreshTimestamp) {
@@ -37,6 +38,33 @@ const Day = () => {
       .join(" ");
   }
 
+  // Patch event category
+  async function patchEvent(event_uid, category_uid, category) {
+    try {
+      const url = `${
+        import.meta.env.VITE_CLOUDFRONT_CALENDAR_EVENTS
+      }/${encodeURIComponent(event_uid)}`;
+
+      const eventResponse = await fetch(url, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          category_uid: category_uid,
+          category: category.toLowerCase(),
+        }),
+        credentials: "include",
+      });
+      if (eventResponse.status === 200) {
+        console.log("Update - Event Category");
+      }
+    } catch (error) {
+      console.error("Sync failed:", error);
+    }
+  }
+
+  // Get all day events
   async function getEvents() {
     try {
       const todaysDate = DateTime.now().toFormat("yyyy-MM-dd");
@@ -60,6 +88,7 @@ const Day = () => {
     }
   }
 
+  // Get all categories
   async function getCategories() {
     try {
       const categoryResponse = await fetch(
@@ -92,43 +121,121 @@ const Day = () => {
   const [editedText, setEditedText] = useState("");
   const editedTextRef = useRef(null);
 
-  const handleCategoryClick = (index, currentText) => {
+  const [filteredCategories, setFilteredCategories] = useState(todayCategories);
+  const [expandUp, setExpandUp] = useState(false);
+  const categoryBubbleRef = useRef(null);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const dropdownItemRefs = useRef([]);
+
+  // Edit category, open list of categories for filtering
+  const handleCategoryClick = (index) => {
     setEditingIndex(index);
-    setEditedText(currentText);
-    // delay to allow render
+    setEditedText("");
+    setExpandUp(false);
+    setHighlightedIndex(-1);
     setTimeout(() => {
       editedTextRef.current?.focus();
+      // expand up if near page end
+      if (categoryBubbleRef.current) {
+        const bubbleRect = categoryBubbleRef.current.getBoundingClientRect();
+
+        const viewportHeight = window.innerHeight;
+        const dropdownHeightEstimate = Math.min(todayCategories.length, 6) * 36; // 36 from item height
+
+        if (
+          bubbleRect.bottom + dropdownHeightEstimate > viewportHeight &&
+          bubbleRect.top > dropdownHeightEstimate / 2
+        ) {
+          setExpandUp(true);
+        } else {
+          setExpandUp(false);
+        }
+      }
     }, 0);
+    setFilteredCategories(todayCategories);
   };
 
+  // Filter Category edit
   const handleTextChange = (e) => {
-    setEditedText(e.target.value);
+    const newText = e.target.value;
+    setEditedText(newText);
+
+    const filtered = todayCategories.filter((categoryItem) =>
+      categoryItem.category.toLowerCase().startsWith(newText.toLowerCase())
+    );
+    setFilteredCategories(filtered);
+    setHighlightedIndex(-1); // highlighted row reset
   };
 
-  const handleBlur = (index) => {
-    if (editedText.trim() === "") {
-      setEditingIndex(null);
-      return;
-    }
+  // Navigate out of edit
+  const handleBlur = () => {
+    setEditingIndex(null);
+    setFilteredCategories(todayCategories);
+    setHighlightedIndex(-1); // highlighted row reset
+  };
 
+  // Update Category key navigation
+  const handleKeyDown = (e, index) => {
+    if (e.key === "Enter") {
+      if (
+        // On enter select highlighted
+        highlightedIndex >= 0 &&
+        filteredCategories.length > highlightedIndex
+      ) {
+        handleDropdownItemClick(
+          index,
+          filteredCategories[highlightedIndex].category
+        );
+      } else if (filteredCategories.length > 0) {
+        // On enter select first
+        handleDropdownItemClick(index, filteredCategories[0].category);
+      } else {
+        // On enter and no options, exit
+        handleBlur();
+      }
+      setHighlightedIndex(-1);
+    } else if (e.key === "Escape") {
+      // exit
+      setEditingIndex(null);
+      setFilteredCategories(todayCategories);
+      setHighlightedIndex(-1);
+    } else if (e.key === "ArrowDown") {
+      // navigate down
+      setHighlightedIndex((prevIndex) =>
+        prevIndex < filteredCategories.length - 1 ? prevIndex + 1 : prevIndex
+      );
+    } else if (e.key === "ArrowUp") {
+      // navigate up
+      setHighlightedIndex((prevIndex) => (prevIndex > 0 ? prevIndex - 1 : -1));
+    }
+  };
+
+  const handleDropdownItemClick = (eventIndex, selectedCategory) => {
+    // Get event UID
+    let eventUID;
     const updatedEvents = calendarEvents.map((event, i) => {
-      if (i === index) {
-        return { ...event, category: titleCase(editedText) };
+      if (i === eventIndex) {
+        eventUID = event.event_uid;
+        return { ...event, category: selectedCategory };
       }
       return event;
     });
+    // get category UID
+    const categoryUID = todayCategories.find(
+      (item) => item.category && item.category === selectedCategory
+    ).category_uid;
+    // update array
     setCalendarEvents(updatedEvents);
+    // send to db
+    patchEvent(eventUID, categoryUID, selectedCategory);
+
+    // reset filters
+    setFilteredCategories(todayCategories);
     setEditingIndex(null);
+    setHighlightedIndex(-1);
   };
 
-  const handleKeyDown = (e, index) => {
-    if (e.key === "Enter") {
-      handleBlur(index);
-    } else if (e.key === "Escape") {
-      setEditingIndex(null);
-    }
-  };
-
+  // Trigger gcal sync
   const handleSync = async () => {
     try {
       const eventResponse = await fetch(
@@ -142,7 +249,6 @@ const Day = () => {
         }
       );
       if (eventResponse.status === 200) {
-        const responseData = await eventResponse.json();
         getEvents();
       }
     } catch (error) {
@@ -151,29 +257,41 @@ const Day = () => {
   };
 
   useEffect(() => {
+    if (highlightedIndex >= 0 && dropdownItemRefs.current[highlightedIndex]) {
+      dropdownItemRefs.current[highlightedIndex].scrollIntoView({
+        block: "nearest",
+        behavior: "smooth",
+      });
+    }
+  }, [highlightedIndex, filteredCategories]);
+
+  useEffect(() => {
+    dropdownItemRefs.current = [];
+  }, [filteredCategories]);
+
+  useEffect(() => {
     getCategories();
     getEvents();
   }, []);
 
   return (
     <div
-      className="bg-[#000000] 
+      className="bg-[#000000]
     /* Layout */
     flex flex-col
-    w-screen min-h-screen m-0
+    w-screen min-h-screen h-auto m-0
     md:flex-row
-    
+
     /* Background */
     bg-[#000000] bg-cover bg-center
-    
+
     /* Spacing */
     pt-5 pl-5 pr-5 px-4 pb-5
     sm:pt-12 sm:pl-20 sm:px-20
-    
+
     text-white"
     >
       <div className="flex flex-col md:w-3/4 md:pr-4 items-start ">
-        {" "}
         {/* First column: graph, title */}
         <div className="flex flex-row">
           <div className="bg-gradient-to-tl from-blue-300 to-orange-100 rounded-full w-12 h-12 flex items-center justify-center text-2xl font-bold text-gray-800 mr-4">
@@ -204,19 +322,56 @@ const Day = () => {
           {calendarEvents.map((event, index) => (
             <div key={index} className="flex items-center">
               {editingIndex === index ? (
-                <input
-                  ref={editedTextRef}
-                  type="text"
-                  value={editedText}
-                  onChange={handleTextChange}
-                  onBlur={() => handleBlur(index)}
-                  onKeyDown={(e) => handleKeyDown(e, index)}
-                  className="bg-gray-700 rounded-full px-3 py-1 mr-2 outline-none focus:ring-2 focus:ring-blue-500"
-                  style={{ width: `${Math.max(editedText.length * 8, 80)}px` }}
-                />
+                // editable
+                <div className="relative">
+                  <input
+                    ref={editedTextRef}
+                    type="text"
+                    value={editedText}
+                    onChange={handleTextChange}
+                    onBlur={() => handleBlur()}
+                    onKeyDown={(e) => handleKeyDown(e, index)}
+                    className="bg-gray-700 rounded-full px-3 py-1 mr-2 outline-none focus:ring-2 focus:ring-blue-500"
+                    style={{
+                      width: `${Math.max(editedText.length * 8, 80)}px`,
+                    }}
+                  />
+                  {/* drop down */}
+                  <div className="relative" ref={categoryBubbleRef}>
+                    <div
+                      className={`absolute left-0
+                  bg-gray-700 rounded-md shadow-lg z-10
+                  overflow-y-auto max-h-48
+                  ${expandUp ? "bottom-[100%] mb-10" : "mt-2"}`}
+                    >
+                      {filteredCategories.map((categoryItem, itemIndex) => (
+                        <div
+                          key={categoryItem.id}
+                          onMouseDown={() =>
+                            handleDropdownItemClick(
+                              index,
+                              categoryItem.category
+                            )
+                          }
+                          ref={(el) =>
+                            (dropdownItemRefs.current[itemIndex] = el)
+                          }
+                          className={`px-4 py-2 cursor-pointer hover:bg-gray-600 transition-colors
+                            ${
+                              itemIndex === highlightedIndex
+                                ? "bg-blue-500"
+                                : ""
+                            }`}
+                        >
+                          {categoryItem.category}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
               ) : (
                 <div
-                  onClick={() => handleCategoryClick(index, event.category)}
+                  onClick={() => handleCategoryClick(index)}
                   className="bg-gray-800 rounded-full px-3 py-1 mr-6 mb-1 cursor-pointer hover:bg-gray-700 transition-colors"
                 >
                   {event.category || "No Category"}


### PR DESCRIPTION
Update:
Add drop down selector of user defined Categories. Typing filters selection list, enter / clicking selects new category. Update is then patched to dynamodb with encoded url.
![image](https://github.com/user-attachments/assets/d9f9e126-2812-4c4c-b5c0-003337c52669)
New options endpoint for /{event_uid}.
Patch event lambda js udpated to decode url.
Get event updated to include category when available in db else Placeholder.

Testing:
On day-view/ clicking category expands category list up when near end of the page, otherwise expands list down for filtering. Navigation with arrow keys selects category.
Graph axes update on selection based off of time attribute.
Dynamodb records are updated with new category_uid, category (lowercase).
Page shows same updated categories on refresh.