### PR TITLE
feat(caching) useEvents & useEventsForRange query hooks

### DIFF
--- a/frontend-web/src/hooks/useEvents.jsx
+++ b/frontend-web/src/hooks/useEvents.jsx
@@ -1,0 +1,25 @@
+// hooks/useEvents.js
+import { useQuery } from "@tanstack/react-query";
+
+export const fetchEventsForDay = async (day) => {
+  const response = await fetch(
+    `${import.meta.env.VITE_CLOUDFRONT_CALENDAR_EVENTS}?event_date=${day}`,
+    {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+    }
+  );
+  if (!response.ok) throw new Error(`Failed to fetch events for ${day}`);
+  const responseData = await response.json();
+  return responseData.events || [];
+};
+
+export const useEvents = (day) => {
+  return useQuery({
+    queryKey: ["events", day], // Unique cache key per day
+    queryFn: () => fetchEventsForDay(day),
+    staleTime: 1000 * 60 * 60 * 24, // 1 day cache
+    retry: 2, // Auto-retry failed fetches
+  });
+};

--- a/frontend-web/src/hooks/useEventsForRange.jsx
+++ b/frontend-web/src/hooks/useEventsForRange.jsx
@@ -1,0 +1,38 @@
+// hooks/useEventsForRange.js
+import { useQueries } from "@tanstack/react-query";
+import { addDays, format, isBefore, isEqual } from "date-fns";
+import { fetchEventsForDay } from "./useEvents";
+
+// array of all days
+function getDaysBetweenDates(startDate, endDate) {
+  const dates = [];
+  let currentDate = new Date(startDate);
+  while (isBefore(currentDate, endDate) || isEqual(currentDate, endDate)) {
+    dates.push(format(currentDate, "yyyy-MM-dd"));
+    currentDate = addDays(currentDate, 1);
+  }
+  return dates;
+}
+export const useEventsForRange = (startDate, endDate) => {
+  const days = getDaysBetweenDates(startDate, endDate);
+
+  const queries = useQueries({
+    queries: days.map((day) => ({
+      queryKey: ["events", day],
+      queryFn: () => fetchEventsForDay(day),
+      staleTime: 5 * 60 * 1000,
+      onSuccess: (data) => console.log(`Success for ${day}:`, data),
+      onError: (error) => console.error(`Error for ${day}:`, error),
+    })),
+  });
+
+  const eventsByDate = new Map(
+    days.map((day, index) => [day, queries[index].data ?? []])
+  );
+
+  return {
+    eventsByDate,
+    isLoading: queries.some((q) => q.isLoading),
+    isError: queries.some((q) => q.isError),
+  };
+};

--- a/frontend-web/src/hooks/useEventsForRange.jsx
+++ b/frontend-web/src/hooks/useEventsForRange.jsx
@@ -32,7 +32,7 @@ export const useEventsForRange = (startDate, endDate) => {
 
   return {
     eventsByDate,
-    isLoading: queries.some((q) => q.isLoading),
-    isError: queries.some((q) => q.isError),
+    eventsIsLoading: queries.some((q) => q.isLoading),
+    eventsIsError: queries.some((q) => q.isError),
   };
 };


### PR DESCRIPTION
closes https://github.com/isabelfaulds/yearly-progress-bars/issues/63

Updates:
Change events retrieval to be retrieve & cache
Testing:
Range-view loads same as previous initially & on date changes