### PR TITLE
fix(auth) added condition for updating refresh token

### DIFF
--- a/backend/auth/auth-token-creation/index.js
+++ b/backend/auth/auth-token-creation/index.js
@@ -44,7 +44,7 @@ async function addUserAndTokens(
         Item: {
           user_id: { S: userID },
           email: { S: email },
-          datetime: { S: datetime },
+          userDatetime: { S: datetime },
         },
       })
     );
@@ -58,7 +58,7 @@ async function addUserAndTokens(
           provider: { S: "firebase" },
           accessToken: { S: gapiToken },
           refreshToken: { S: refreshToken },
-          datetime: { S: datetime },
+          tokenTimestamp: { S: datetime },
           expiresIn: { N: "3600" },
         },
       })
@@ -72,7 +72,7 @@ async function addUserAndTokens(
           user_id: { S: userID },
           accessToken: { S: cookieToken },
           refreshToken: { S: refreshCookieToken },
-          datetime: { S: datetime },
+          tokenTimestamp: { S: datetime },
           accessTokenexpiresIn: { N: "3600" },
           refreshTokenexpiresIn: { N: "36000" },
         },
@@ -94,21 +94,12 @@ exports.handler = async (event) => {
     accessControlAllowOrigin = origin;
   }
 
-  if (event.httpMethod === "OPTIONS") {
-    return {
-      statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": accessControlAllowOrigin,
-        ...corsHeaders,
-      },
-      body: "",
-    };
-  }
-
   let requestBody = event.body;
   if (typeof requestBody === "string") {
     requestBody = JSON.parse(requestBody);
   }
+  console.log("Request Body:", requestBody);
+
   const userID = requestBody.userID;
   const email = requestBody.email;
   const token = requestBody.token;
@@ -116,7 +107,6 @@ exports.handler = async (event) => {
   const refreshToken = requestBody.refreshToken;
   const datetime = requestBody.datetime;
   const expiresIn = requestBody.expiresIn;
-  console.log("Request Body:", requestBody);
   console.log("token", token);
 
   if (!admin.apps.length) {

--- a/backend/lambda-edge-cookie-parser/index.js
+++ b/backend/lambda-edge-cookie-parser/index.js
@@ -4,7 +4,7 @@ exports.handler = (event, context, callback) => {
   const request = event.Records[0].cf.request;
   const headers = request.headers;
 
-  if (headers.cookie) {
+  try {
     const cookies = headers.cookie[0].value.split("; ");
     const accessToken = cookies
       .find((cookie) => cookie.startsWith("accessToken="))
@@ -19,6 +19,8 @@ exports.handler = (event, context, callback) => {
       ];
       headers["user-id"] = [{ key: "user-id", value: userID }];
     }
+  } catch (error) {
+    console.log("Caught error", error);
   }
 
   callback(null, request);

--- a/frontend-web/src/hooks/useAuth.jsx
+++ b/frontend-web/src/hooks/useAuth.jsx
@@ -1,15 +1,7 @@
 import React, { createContext, useState, useEffect } from "react";
 import "firebase/auth";
-import {
-  signInWithRedirect,
-  signInWithPopup,
-  GoogleAuthProvider,
-  getRedirectResult,
-  browserLocalPersistence,
-  onAuthStateChanged,
-  setPersistence,
-} from "firebase/auth";
-import { app, auth } from "../firebase.js";
+import { signInWithPopup, GoogleAuthProvider } from "firebase/auth";
+import { auth } from "../firebase.js";
 
 const googleProvider = new GoogleAuthProvider();
 googleProvider.addScope("https://www.googleapis.com/auth/userinfo.email");
@@ -17,7 +9,6 @@ googleProvider.addScope("https://www.googleapis.com/auth/userinfo.profile");
 googleProvider.addScope("openid");
 googleProvider.addScope("https://www.googleapis.com/auth/calendar.readonly");
 googleProvider.addScope("https://www.googleapis.com/auth/tasks.readonly");
-
 const AuthContext = createContext();
 
 export function AuthProvider({ children }) {
@@ -38,18 +29,49 @@ export function AuthProvider({ children }) {
       );
       if (authCheckResponse.status === 200) {
         setIsSignedIn(true);
+        return true;
       } else {
         setIsSignedIn(false);
+        return false;
       }
     } catch (error) {
-      console.error("Auth check failed:", error);
+      setIsSignedIn(false);
+      return false;
+    }
+  };
+
+  // refresh
+  const checkRefreshCookie = async () => {
+    const authResponse = await fetch(import.meta.env.VITE_API_GATEWAY_REFRESH, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    });
+    if (authResponse.status === 200) {
+      setIsSignedIn(true);
+      return true;
+    } else {
+      return false;
     }
   };
 
   // initial set access token
   useEffect(() => {
-    checkLoginCookie();
-    checkRefreshCookie();
+    const initializeAuth = async () => {
+      const loginCheckSuccess = await checkLoginCookie();
+      if (loginCheckSuccess) {
+        console.log("Auth - access success");
+      }
+      if (!loginCheckSuccess) {
+        const refreshCheckSuccess = await checkRefreshCookie();
+        if (refreshCheckSuccess) {
+          ("Auth - refreshed");
+        }
+      }
+    };
+    initializeAuth();
   }, []);
 
   // sign in
@@ -77,6 +99,7 @@ export function AuthProvider({ children }) {
           }
         );
         if (authResponse.status === 200) {
+          console.log("auth response result");
           checkLoginCookie();
         } else {
           const errorResponse = await authResponse.text();
@@ -103,20 +126,6 @@ export function AuthProvider({ children }) {
       credentials: "include",
     });
     setIsSignedIn(false);
-  };
-
-  // refresh
-  const checkRefreshCookie = async () => {
-    const authResponse = await fetch(import.meta.env.VITE_API_GATEWAY_REFRESH, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      credentials: "include",
-    });
-    if (authResponse.status === 200) {
-      setIsSignedIn(true);
-    }
   };
 
   return (


### PR DESCRIPTION
Updates
- Changed token refresh to use dynamodb condition to prevent multiple requests from rewriting db
- Changed lambda edge parser to catch errors for missing tokens
- Auth hook changed to only check refresh on login fail
- Removed access token storage
Testing
- refreshToken check not performed on page refreshes
- Deleting both cookies prompts sign in
- Deleting just access token results in refresh
