### PR TITLE
feat(login) components for calendar settings table

### DIFF
--- a/frontend-web/package-lock.json
+++ b/frontend-web/package-lock.json
@@ -11,9 +11,13 @@
       "dependencies": {
         "-": "^0.0.1",
         "@heroicons/react": "^2.2.0",
+        "@hookform/resolvers": "^5.1.1",
+        "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-scroll-area": "^1.2.9",
+        "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@tailwindcss/vite": "^4.1.7",
         "@tanstack/react-query": "^5.77.2",
@@ -31,11 +35,13 @@
         "react": "^18.3.1",
         "react-day-picker": "^9.7.0",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.58.1",
         "react-number-format": "^5.4.4",
         "react-router-dom": "^7.1.5",
         "save": "^2.9.0",
         "tailwind-merge": "^3.3.1",
-        "vite-plugin-mkcert": "^1.17.8"
+        "vite-plugin-mkcert": "^1.17.8",
+        "zod": "^3.25.67"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -3049,6 +3055,18 @@
         "react": ">= 16 || ^19.0.0-rc"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3280,6 +3298,62 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.2.tgz",
+      "integrity": "sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -3442,6 +3516,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -3617,6 +3714,49 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.5.tgz",
+      "integrity": "sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -3720,6 +3860,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-rect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
@@ -3752,6 +3907,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -4044,6 +4222,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -8378,6 +8562,22 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.58.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.58.1.tgz",
+      "integrity": "sha512-Lml/KZYEEFfPhUVgE0RdCVpnC4yhW+PndRhbiTtdvSlQTL8IfVR+iQkBjLIvmmc6+GGoVeM11z37ktKFPAb0FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -9884,6 +10084,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend-web/package.json
+++ b/frontend-web/package.json
@@ -12,9 +12,13 @@
   "dependencies": {
     "-": "^0.0.1",
     "@heroicons/react": "^2.2.0",
+    "@hookform/resolvers": "^5.1.1",
+    "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-scroll-area": "^1.2.9",
+    "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/vite": "^4.1.7",
     "@tanstack/react-query": "^5.77.2",
@@ -32,11 +36,13 @@
     "react": "^18.3.1",
     "react-day-picker": "^9.7.0",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.58.1",
     "react-number-format": "^5.4.4",
     "react-router-dom": "^7.1.5",
     "save": "^2.9.0",
     "tailwind-merge": "^3.3.1",
-    "vite-plugin-mkcert": "^1.17.8"
+    "vite-plugin-mkcert": "^1.17.8",
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/frontend-web/src/components/login-pages/CalendarTable.jsx
+++ b/frontend-web/src/components/login-pages/CalendarTable.jsx
@@ -15,8 +15,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 
 import { getColumns } from "./columns";
+import { Scroll } from "lucide-react";
 
 const CalendarTable = forwardRef(({ data, categories }, ref) => {
   const [internalData, setInternalData] = useState(data || []);
@@ -44,48 +46,55 @@ const CalendarTable = forwardRef(({ data, categories }, ref) => {
   }));
 
   return (
-    <div className="rounded-md border">
-      <Table>
-        <TableHeader>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <TableHead key={header.id}>
-                  {header.isPlaceholder
-                    ? null
-                    : typeof header.column.columnDef.header === "function"
-                    ? // Render header content , components
-                      header.column.columnDef.header(header.getContext())
-                    : header.column.columnDef.header}
-                </TableHead>
-              ))}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {table.getRowModel().rows?.length ? (
-            table.getRowModel().rows.map((row) => (
-              <TableRow
-                key={row.id} // react table id
-                data-state={row.getIsSelected() && "selected"}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {/* Render cell content , components */}
-                    {cell.column.columnDef.cell(cell.getContext())}
-                  </TableCell>
+    <div className="rounded-md m-3 font-lex">
+      <ScrollArea className="rounded-md w-full relative overflow-x-auto">
+        <Table className="rounded-md min-w-[600px]">
+          <TableHeader className="bg-slate-800 px-4">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : typeof header.column.columnDef.header === "function"
+                      ? // Render header content , components
+                        header.column.columnDef.header(header.getContext())
+                      : header.column.columnDef.header}
+                  </TableHead>
                 ))}
               </TableRow>
-            ))
-          ) : (
-            <TableRow>
-              <TableCell colSpan={columns.length} className="h-24 text-center">
-                No results.
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id} // react table id
+                  data-state={row.getIsSelected() && "selected"}
+                  className="bg-coolgray"
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {/* Render cell content , components */}
+                      {cell.column.columnDef.cell(cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
     </div>
   );
 });

--- a/frontend-web/src/components/login-pages/CalendarTable.jsx
+++ b/frontend-web/src/components/login-pages/CalendarTable.jsx
@@ -1,0 +1,93 @@
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
+import { useReactTable, getCoreRowModel } from "@tanstack/react-table";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import { getColumns } from "./columns";
+
+const CalendarTable = forwardRef(({ data, categories }, ref) => {
+  const [internalData, setInternalData] = useState(data || []);
+
+  // Include fetched categories in table column component
+  const columns = useMemo(
+    () => getColumns(categories, setInternalData),
+    [categories]
+  );
+
+  // Create table with columns
+  const table = useReactTable({
+    data: internalData,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    enableRowSelection: true,
+  });
+
+  // Get checkbox , dropdown column updates
+  useEffect(() => {
+    setInternalData(data || []);
+  }, [data]);
+  useImperativeHandle(ref, () => ({
+    getCurrentState: () => internalData,
+  }));
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id}>
+                  {header.isPlaceholder
+                    ? null
+                    : typeof header.column.columnDef.header === "function"
+                    ? // Render header content , components
+                      header.column.columnDef.header(header.getContext())
+                    : header.column.columnDef.header}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id} // react table id
+                data-state={row.getIsSelected() && "selected"}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {/* Render cell content , components */}
+                    {cell.column.columnDef.cell(cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-24 text-center">
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+});
+
+export default CalendarTable;

--- a/frontend-web/src/components/login-pages/LoginStep2.jsx
+++ b/frontend-web/src/components/login-pages/LoginStep2.jsx
@@ -42,7 +42,6 @@ const LoginStep2 = ({ onNext }) => {
 
   const handleCategorySave = () => {
     const totalMinutes = newCategory.hours * 60 + newCategory.minutes * 1;
-    console.log(newCategory.hours * 60, totalMinutes);
     const totalHours = Math.floor(totalMinutes / 60);
     const remainderMinutes = totalMinutes % 60;
     setNewCategories((prevCategories) => [

--- a/frontend-web/src/components/login-pages/LoginStep3.jsx
+++ b/frontend-web/src/components/login-pages/LoginStep3.jsx
@@ -1,19 +1,84 @@
 import { Button } from "@/components/ui/button.jsx";
 import { useNavigate } from "react-router-dom";
+import { useEffect, useState, useRef } from "react";
+import CalendarTable from "./CalendarTable";
+import { useCategories } from "@/hooks/useCategories";
 
 const LoginStep3 = () => {
+  const { data: categories, isLoading, error } = useCategories();
   const navigate = useNavigate();
-  const handleSave = () => {
+
+  // Get list of calendars
+  const [calendars, setCalendars] = useState([]);
+  const getCalendars = async () => {
+    const response = await fetch(import.meta.env.VITE_CLOUDFRONT_GCAL_LIST, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+    });
+    if (!response.ok) throw new Error("Failed to fetch categories");
+    const data = await response.json();
+    setCalendars(data.calendars);
+    console.log(data);
+  };
+
+  useEffect(() => {
+    getCalendars();
+  }, []);
+
+  // Get selections
+  const tableRef = useRef();
+
+  const handleFinish = async () => {
+    const latestData = tableRef.current.getCurrentState();
+    console.log("Final table state", latestData);
+
+    const mappedData = latestData
+      .filter((item) => item.selected)
+      .map(({ defaultCategory, ...rest }) => ({
+        ...rest,
+        defaultCategory: defaultCategory?.toLowerCase() ?? null,
+        sync: true,
+      }));
+    console.log("mappedData", mappedData);
+
+    const finish = await Promise.all(
+      latestData
+        .filter((item) => item.selected)
+        .map(({ defaultCategory, ...rest }) => ({
+          ...rest,
+          defaultCategory: defaultCategory?.toLowerCase() ?? null,
+          sync: true,
+        }))
+        .map((item) =>
+          fetch(import.meta.env.VITE_CLOUDFRONT_GCAL_LIST, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            credentials: "include",
+            body: JSON.stringify(item),
+          })
+        )
+    );
+    console.log("Updated - Calendar settings");
     navigate("/day-view");
   };
+
   return (
     <div className="initial-container">
       <div className="mb-10">
-        <div className="text-xl mb-10">Sign up for Progress Bars</div>
+        <div className="text-xl mb-10">Set Calendar Preferences</div>
       </div>
-      <div className="">Set Calendar Preferences</div>
+      <div className="m-3">Choose Calendars to Sync</div>
+      <div className="m-2">
+        Select calendars and set any preferred defaults, make changes later in
+        Settings{" "}
+      </div>
+
+      <CalendarTable data={calendars} categories={categories} ref={tableRef} />
       <div className="m-3 flex flex-col gap-3 mx-auto">
-        <Button onClick={handleSave} className="mx-auto p-2 max-w-1/3">
+        <Button onClick={handleFinish} className="mx-auto p-2 max-w-1/3">
           Finish
         </Button>
       </div>

--- a/frontend-web/src/components/login-pages/LoginStep3.jsx
+++ b/frontend-web/src/components/login-pages/LoginStep3.jsx
@@ -67,17 +67,16 @@ const LoginStep3 = () => {
 
   return (
     <div className="initial-container">
-      <div className="mb-10">
+      <div className="mb-10 font-lexend">
         <div className="text-xl mb-10">Set Calendar Preferences</div>
       </div>
       <div className="m-3">Choose Calendars to Sync</div>
-      <div className="m-2">
+      <div className="m-2 mb-4">
         Select calendars and set any preferred defaults, make changes later in
         Settings{" "}
       </div>
-
       <CalendarTable data={calendars} categories={categories} ref={tableRef} />
-      <div className="m-3 flex flex-col gap-3 mx-auto">
+      <div className="mt-4 m-3 flex flex-col gap-3 mx-auto">
         <Button onClick={handleFinish} className="mx-auto p-2 max-w-1/3">
           Finish
         </Button>

--- a/frontend-web/src/components/login-pages/columns.jsx
+++ b/frontend-web/src/components/login-pages/columns.jsx
@@ -1,0 +1,118 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export const getColumns = (categories = [], setInternalData) => {
+  return [
+    // Checkbox Column
+    {
+      id: "select", // column id
+      header: ({ table }) => (
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            checked={
+              table.getIsAllPageRowsSelected() ||
+              (table.getIsSomePageRowsSelected() && "indeterminate")
+            }
+            onCheckedChange={(value) => {
+              const checked = !!value;
+              // Update internal state
+              setInternalData((prev) =>
+                prev.map((item) => ({
+                  ...item,
+                  selected: checked,
+                }))
+              );
+              // Update table selection state
+              table.toggleAllPageRowsSelected(checked);
+            }}
+            aria-label="Select all"
+          />
+          <span>Include</span>
+        </div>
+      ),
+      cell: ({ row }) => {
+        const handleCheckboxChange = (value) => {
+          row.toggleSelected(!!value);
+          setInternalData((prev) =>
+            prev.map((item) =>
+              item.calendarID === row.original.calendarID
+                ? { ...item, selected: !!value }
+                : item
+            )
+          );
+        };
+
+        return (
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={handleCheckboxChange}
+            aria-label="Select row"
+          />
+        );
+      },
+      enableSorting: false,
+      enableHiding: false,
+    },
+
+    // Name Column
+    {
+      accessorKey: "summary",
+      header: "Calendar Name",
+      cell: ({ row }) => (
+        <div className="font-lexend">{row.original.summary}</div>
+      ),
+    },
+
+    // Dropdown Column
+    {
+      id: "defaultCategory",
+      header: "Default Category",
+      cell: ({ row }) => {
+        const calendarItem = row.original;
+        const handleDropdownChange = (value) => {
+          setInternalData((prev) =>
+            prev.map((item) =>
+              item.calendarID === row.original.calendarID
+                ? { ...item, defaultCategory: value }
+                : item
+            )
+          );
+        };
+
+        return (
+          <Select onValueChange={handleDropdownChange}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue
+                placeholder={calendarItem.defaultCategory || "None set"}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {categories.length > 0 ? (
+                categories.map((category) => (
+                  <SelectItem
+                    key={category.category_uid}
+                    value={category.category || "Placeholder"}
+                  >
+                    {category.category || "Placeholder"}
+                  </SelectItem>
+                ))
+              ) : (
+                <SelectItem value="no-categories" disabled>
+                  Loading categories...
+                </SelectItem>
+              )}
+            </SelectContent>
+          </Select>
+        );
+      },
+      enableSorting: false,
+      enableHiding: false,
+    },
+  ];
+};

--- a/frontend-web/src/components/login-pages/columns.jsx
+++ b/frontend-web/src/components/login-pages/columns.jsx
@@ -65,7 +65,9 @@ export const getColumns = (categories = [], setInternalData) => {
       accessorKey: "summary",
       header: "Calendar Name",
       cell: ({ row }) => (
-        <div className="font-lexend">{row.original.summary}</div>
+        <div className="font-lexend items-cente max-w-[120px] sm:max-w-[225px] md:max-w-[400px] lg:md:max-w-[800px] break-words whitespace-normal">
+          {row.original.summary}
+        </div>
       ),
     },
 
@@ -86,29 +88,31 @@ export const getColumns = (categories = [], setInternalData) => {
         };
 
         return (
-          <Select onValueChange={handleDropdownChange}>
-            <SelectTrigger className="w-[180px]">
-              <SelectValue
-                placeholder={calendarItem.defaultCategory || "None set"}
-              />
-            </SelectTrigger>
-            <SelectContent>
-              {categories.length > 0 ? (
-                categories.map((category) => (
-                  <SelectItem
-                    key={category.category_uid}
-                    value={category.category || "Placeholder"}
-                  >
-                    {category.category || "Placeholder"}
+          <div className="flex items-center justify-center">
+            <Select onValueChange={handleDropdownChange}>
+              <SelectTrigger className="w-[180px]  data-[placeholder]:text-gray-400">
+                <SelectValue
+                  placeholder={calendarItem.defaultCategory || "None set"}
+                />
+              </SelectTrigger>
+              <SelectContent className="bg-slate-600 text-white">
+                {categories.length > 0 ? (
+                  categories.map((category) => (
+                    <SelectItem
+                      key={category.category_uid}
+                      value={category.category || "Placeholder"}
+                    >
+                      {category.category || "Placeholder"}
+                    </SelectItem>
+                  ))
+                ) : (
+                  <SelectItem value="no-categories" disabled>
+                    Loading categories...
                   </SelectItem>
-                ))
-              ) : (
-                <SelectItem value="no-categories" disabled>
-                  Loading categories...
-                </SelectItem>
-              )}
-            </SelectContent>
-          </Select>
+                )}
+              </SelectContent>
+            </Select>
+          </div>
         );
       },
       enableSorting: false,

--- a/frontend-web/src/components/ui/checkbox.jsx
+++ b/frontend-web/src/components/ui/checkbox.jsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}>
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none">
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox }

--- a/frontend-web/src/components/ui/select.jsx
+++ b/frontend-web/src/components/ui/select.jsx
@@ -1,0 +1,164 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}>
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        {...props}>
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn("p-1", position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1")}>
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props} />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}>
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props} />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}>
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}>
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/terraform/apigateway.tf
+++ b/terraform/apigateway.tf
@@ -172,7 +172,7 @@ resource "aws_api_gateway_integration_response" "auth_options_integration_respon
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type'"
     "method.response.header.Access-Control-Allow-Methods" = "'OPTIONS,POST'"
-    "method.response.header.Access-Control-Allow-Origin" = "'https://localhost:5173'"
+    "method.response.header.Access-Control-Allow-Origin" = "'https://year-progress-bar.com'"
     "method.response.header.Access-Control-Allow-Credentials": "'true'"
   }
 
@@ -180,7 +180,7 @@ resource "aws_api_gateway_integration_response" "auth_options_integration_respon
     "application/json" = jsonencode({
       statusCode = 200
       headers = {
-        "Access-Control-Allow-Origin"      = "'https://localhost:5173'"
+        "Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'"
         "Access-Control-Allow-Methods"     = "POST, OPTIONS"
         "Access-Control-Allow-Headers"     = "'Content-Type'"
         "Access-Control-Allow-Credentials" = "'true'" # Client expects string
@@ -287,7 +287,7 @@ resource "aws_api_gateway_integration_response" "auth_logout_options_integration
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,POST'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 
@@ -391,7 +391,7 @@ resource "aws_api_gateway_integration_response" "auth_refresh_options_integratio
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,POST'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 
@@ -493,7 +493,7 @@ resource "aws_api_gateway_integration_response" "auth_check_options_integration_
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,POST'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -628,7 +628,7 @@ resource "aws_api_gateway_integration_response" "calendar_events_options_integra
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -733,7 +733,7 @@ resource "aws_api_gateway_integration_response" "calendar_event_options_integrat
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,PATCH'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -838,7 +838,7 @@ resource "aws_api_gateway_integration_response" "sync_gcal_options_integration_r
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -935,7 +935,7 @@ resource "aws_api_gateway_integration_response" "categories_options_integration_
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET,POST'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -1079,7 +1079,7 @@ resource "aws_api_gateway_integration_response" "labeling_categories_options_int
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET,POST'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -1213,7 +1213,7 @@ resource "aws_api_gateway_integration_response" "user_settings_options_integrati
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET,PATCH'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -1274,7 +1274,7 @@ resource "aws_api_gateway_integration_response" "saved_items_options_integration
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET,POST'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -1358,7 +1358,7 @@ resource "aws_api_gateway_integration_response" "saved_items_post_integration_re
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET,POST'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
   response_templates = {
@@ -1467,7 +1467,7 @@ EOF
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,POST,GET'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -1528,7 +1528,7 @@ resource "aws_api_gateway_integration_response" "milestones_options_integration_
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET,POST,PATCH,DELETE'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -1647,7 +1647,7 @@ resource "aws_api_gateway_integration_response" "get_milestones_by_index_integra
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,POST,PATCH,GET'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -1735,7 +1735,7 @@ resource "aws_api_gateway_integration_response" "post_milestone_integration_resp
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
     "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET,POST'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
   response_templates = {
@@ -1807,8 +1807,8 @@ resource "aws_api_gateway_integration_response" "cal_list_options_integration_re
 
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
-    "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET,POST'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
 }
@@ -1864,10 +1864,101 @@ resource "aws_api_gateway_integration_response" "get_calendars_integration_respo
 
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
-    "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET'",
-    "method.response.header.Access-Control-Allow-Origin"      = "'https://localhost:5173'",
+    "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET,POST'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
   }
   
 }
 
+### post preferences
+
+resource "aws_api_gateway_method" "post_calendars_list_method" {
+  rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
+  resource_id   = aws_api_gateway_resource.cal_list.id
+  http_method   = "POST"
+  authorization = "CUSTOM"
+  authorizer_id = aws_api_gateway_authorizer.login_token_gateway_authorizer.id
+
+  request_parameters = {
+    "method.request.header.user-id" = true,
+  }
+}
+
+resource "aws_api_gateway_integration" "post_calendar_list" {
+  rest_api_id = aws_api_gateway_rest_api.user_data_api.id
+  resource_id = aws_api_gateway_method.post_calendars_list_method.resource_id
+  http_method = aws_api_gateway_method.post_calendars_list_method.http_method
+  integration_http_method = "POST"
+  type                    = "AWS" 
+  credentials             = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/APIGatewayDyanmoCloudWatchRole"
+  uri = "arn:aws:apigateway:us-west-1:dynamodb:action/PutItem"
+  passthrough_behavior = "WHEN_NO_MATCH"
+
+
+# 400 if improper template
+  request_templates = {
+    "application/json" = <<EOF
+    #set($inputRoot = $input.path('$'))
+    #set($userId = $input.params().header.get('user-id'))
+    #set($calendarID = $inputRoot.calendarID)
+    #set($defaultCategory = $inputRoot.defaultCategory)
+    #set($sync = $inputRoot.sync)
+    #set($summary = $inputRoot.summary)
+
+
+    {
+      "TableName": "pb_calendars",
+      "Item": {
+        "calendar_uid" : {"S" : "$userId:$calendarID"}
+        ,"user_id" : { "S": "$userId" }
+        ,"sync" : {"BOOL" : $sync}
+        ,"calendar_name" : { "S": "$summary" }
+        #if($inputRoot.defaultCategory && $inputRoot.defaultCategory != "")
+          , "default_category_uid" : { "S" : "$userId:$inputRoot.defaultCategory" }
+          , "default_category" : { "S" : "$inputRoot.defaultCategory" }
+        #end
+
+      }
+    }
+EOF
+  }
+}
+
+resource "aws_api_gateway_method_response" "post_calendar_list_method_response" {
+  rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
+  resource_id   = aws_api_gateway_resource.cal_list.id
+  http_method   = "POST"
+  status_code   = "200"
+  depends_on = [aws_api_gateway_method.post_calendars_list_method]
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers"     = true,
+    "method.response.header.Access-Control-Allow-Methods"     = true,
+    "method.response.header.Access-Control-Allow-Origin"      = true,
+    "method.response.header.Access-Control-Allow-Credentials" = true
+  }
+}
+
+resource "aws_api_gateway_integration_response" "post_calendar_list_integration_response" {
+  rest_api_id   = aws_api_gateway_rest_api.user_data_api.id
+  resource_id   = aws_api_gateway_resource.cal_list.id
+  http_method   = "POST"
+  status_code   = "200"
+
+  depends_on = [
+    aws_api_gateway_integration.post_calendar_list,
+  ]
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type'",
+    "method.response.header.Access-Control-Allow-Methods"     = "'OPTIONS,GET,POST'",
+    "method.response.header.Access-Control-Allow-Origin"      = "'https://year-progress-bar.com'",
+    "method.response.header.Access-Control-Allow-Credentials" = "'true'"
+  }
+  response_templates = {
+          "application/json" = <<EOF
+      {"message": "Updated calendar settings"}
+      EOF
+        }
+}

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -172,3 +172,29 @@ resource "aws_dynamodb_table" "milestones" {
   }
 
 }
+
+resource "aws_dynamodb_table" "calendars" {
+  name = "pb_calendars"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "calendar_uid"
+
+  attribute {
+    name = "calendar_uid"
+    type = "S"
+  }
+
+  attribute {
+    name = "user_id"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "UserIndex"
+    hash_key        = "user_id"
+    projection_type = "ALL"
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+}


### PR DESCRIPTION
Updates:
- Login step 3, initial calendar settings page
- fetches calendars from list endpoint & renders in table for inclusion & setting default category
- dynamodb created for calendar settings
- api endpoint for posting changes directly to dynamodb
- shadcn generated dependencies for selection



Testing:
- Finish button saves calendar uid , category, sync into dynamo
- Only data on calendars specified for including is saved

![image](https://github.com/user-attachments/assets/bf42ca30-14b4-4bd7-844a-0cf5054f6dcb)
