### PR TITLE
feat(airflow) cron scheduler

### DIFF
--- a/dags/day_metrics.py
+++ b/dags/day_metrics.py
@@ -82,9 +82,9 @@ def extract_transform_load():
 with DAG(
     dag_id="day_metrics",
     start_date=datetime(2025, 7, 1),
-    schedule="10 8 * * *",  # UTC for PST = 12:10 am
+    schedule="15 7 * * *",  # 7:15 UTC for PST = 12:15 am , will need to be changed in november
     catchup=False,
-    tags=["example"]
+    tags=["day"]
 ) as dag:
     etl_task = PythonOperator(
         task_id="run_etl",

--- a/terraform/airflow.tf
+++ b/terraform/airflow.tf
@@ -294,7 +294,7 @@ resource "aws_scheduler_schedule" "airflow_instance_stop_schedule" {
   flexible_time_window {
     mode = "OFF"
   }
-  schedule_expression = "cron(20 0 * * ? *)" # 12:20 am , minute hour month-day month week-day year
+  schedule_expression = "cron(25 0 * * ? *)" # 12:25 am pst
   schedule_expression_timezone = "US/Pacific"
   description = "daily stop airflow instance"
 
@@ -344,7 +344,7 @@ resource "aws_scheduler_schedule" "daily_script_schedule" {
   flexible_time_window {
     mode = "OFF"
   }
-  schedule_expression          = "cron(5 0 * * ? *)" # 12:05 daily
+  schedule_expression          = "cron(5 0 * * ? *)" # 12:05 daily , dags at 12:15
   schedule_expression_timezone = "US/Pacific"
   description                  = "daily run of docker up airflow up script"
 

--- a/terraform/airflow/start_airflow.sh
+++ b/terraform/airflow/start_airflow.sh
@@ -1,9 +1,35 @@
 #!/bin/bash
-cd /home/ec2-user/airflow
+
+LOG_FILE="/home/ec2-user/startcommand_scheduler.log"
+# logging formatter
+log() {
+    echo "$(date -u '+%Y-%m-%d %H:%M:%S') - $*" >> "$LOG_FILE"
+}
+
+log "Script started"
+log "Running as user: $(whoami)"
+log "Current directory: $(pwd)"
+cd airflow
+log "Current directory: $(pwd)"
+log "Copy dag"
+aws s3 cp s3://pb-dags/day_metrics.py /home/ec2-user/airflow/dags/day_metrics.py >> "$LOG_FILE" 2>&1
+
+# ensure variables
+export AIRFLOW_UID=$(id -u ec2-user)
+echo "AIRFLOW_UID=$(id -u ec2-user)" > .env
 echo "POSTGRES_USER=airflow" > .env
 echo "POSTGRES_PASSWORD=airflow" > .env
-echo "[INFO] Starting Airflow containers at $(date)" >> /home/ec2-user/airflow/cron.log
-/usr/bin/docker compose up -d
-docker exec -it airflow-airflow-scheduler-1 airflow dags unpause day_metrics
-#  docker start airflow-airflow-worker-1
-echo "[INFO] Done at $(date)" >> /home/ec2-user/airflow/cron.log
+log "Environment: $(env)"
+
+log "Start Docker"
+sudo systemctl start docker >> "$LOG_FILE" 2>&1
+log "Verify Docker"
+sudo systemctl status docker >> "$LOG_FILE" 2>&1
+log "Docker Up"
+/usr/bin/docker compose up -d >> "$LOG_FILE" 2>&1
+# let docker start
+sleep 30
+log "Unpause dag"
+# ensure dag unpaused
+docker exec airflow-airflow-scheduler-1 airflow dags unpause day_metrics >> "$LOG_FILE" 2>&1
+log "Script completed"


### PR DESCRIPTION
crontab -e less reliable for airflow instance than using eventbridge scheduler to invoke running shell script & ensuring environment variables
included copying dag file


Update
- scheduler resource for running start_airflow.sh
- added ssm permission to ec2 airflow role
- updated stop instance & dag schedule


Schedule:
12:00 start instance
12:05 cron script docker up , unpause dag
12:15 dag schedule
12:25 stop instance

Testing
- [x] job running across multiple start stops tests
- [x] job logging in ec2 log file


using utc for pst in day_metrics.py will need to be changed in november!
