### PR TITLE
feat(dags) category day metrics table

### DIFF
--- a/dags/category_day_metrics.py
+++ b/dags/category_day_metrics.py
@@ -1,0 +1,106 @@
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import PythonOperator
+from boto3.dynamodb.conditions import Key
+from datetime import datetime
+import boto3
+import pandas as pd
+from decimal import Decimal
+from datetime import timedelta
+
+
+def extract_transform_load():
+    dynamodb = boto3.resource("dynamodb", region_name="us-west-1")
+    today = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+    print("Querying DateIndex for date:", today)
+
+    events = dynamodb.Table("pb_events")
+    categories = dynamodb.Table("pb_categories")
+    pb_category_day_metrics = dynamodb.Table("pb_category_day_metrics")
+
+    # Query events table for today's (yesterday , run at midnight) date
+    event_response = events.query(
+        IndexName="DateIndex", KeyConditionExpression=Key("event_startdate").eq(today)
+    )
+    df_events = pd.DataFrame(event_response.get("Items", []))
+
+    # Scan categories
+    category_response = categories.scan()
+    df_categories = pd.DataFrame(category_response.get("Items", []))
+    df_categories = df_categories[
+        (df_categories["category"] != "Placeholder")
+        & (df_categories["minutes"].notna())
+    ]
+    print(f"Events: {df_events.shape[0]} rows")
+    print(f"Categories: {df_categories.shape[0]} rows")
+
+    if df_events.empty:
+        print("No data found for today.")
+        return
+
+    df_events["minutes"] = pd.to_numeric(df_events["minutes"], errors="coerce")
+    # category minutes as queried on that day
+    df_categories["planned_minutes"] = pd.to_numeric(
+        df_categories["minutes"], errors="coerce"
+    )
+
+    # Join events onto all categories , on user_id and category
+    df_joined = pd.merge(
+        df_categories[["user_id", "category", "planned_minutes"]],
+        df_events,
+        on=["user_id", "category"],
+        how="left",
+    )
+
+    # Group and calculate
+    df_result = (
+        df_joined.groupby(["user_id", "category", "planned_minutes"], as_index=False)
+        .agg({"minutes": "sum", "event_uid": "count"})
+        .reset_index(drop=True)
+        .rename({"minutes": "total_minutes", "event_uid": "total_sessions"}, axis=1)
+    )
+    print(f"Result DF after groupby: {df_result.shape[0]} rows")
+
+    # Metrics
+    df_result = df_result.assign(
+        fulfillment_score=(
+            df_result["total_minutes"] / df_result["planned_minutes"]
+        ).clip(upper=1)
+        * 100,  # capping at 1 , 100
+        consistency_score=(df_result["total_minutes"] > 0).astype(int),
+        category_date_id=df_result["user_id"]
+        + ":"
+        + df_result["category"]
+        + ":"
+        + today,
+    )
+
+    # Convert float columns to Decimal for DynamoDB
+    df_result["total_minutes"] = df_result["total_minutes"].apply(
+        lambda x: Decimal(str(x))
+    )
+    df_result["fulfillment_score"] = df_result["fulfillment_score"].apply(
+        lambda x: Decimal(str(x))
+    )
+    df_result["planned_minutes"] = df_result["planned_minutes"].apply(
+        lambda x: Decimal(str(x))
+    )
+    df_result["consistency_score"] = df_result["consistency_score"].apply(
+        lambda x: Decimal(str(x))
+    )
+
+    with pb_category_day_metrics.batch_writer() as batch:
+        for row in df_result.to_dict(orient="records"):
+            batch.put_item(Item=row)
+
+    print(f"Inserted {len(df_result)} rows to pb_category_day_metrics")
+
+
+with DAG(
+    dag_id="category_day_metrics",
+    start_date=datetime(2025, 7, 1),
+    schedule="15 7 * * *",  # 7:15 UTC for PST = 12:15 am , will need to be changed in november
+    catchup=False,
+    tags=["day"],
+) as dag:
+    etl_task = PythonOperator(task_id="run_etl", python_callable=extract_transform_load)

--- a/terraform/airflow.tf
+++ b/terraform/airflow.tf
@@ -98,7 +98,8 @@ resource "aws_iam_policy" "airflow_dynamodb_access_policy" {
         "arn:aws:dynamodb:us-west-1:${data.aws_caller_identity.current.account_id}:table/pb_events/index/DateIndex",
         "arn:aws:dynamodb:us-west-1:${data.aws_caller_identity.current.account_id}:table/pb_events",
         "arn:aws:dynamodb:us-west-1:${data.aws_caller_identity.current.account_id}:table/pb_categories",
-        "arn:aws:dynamodb:us-west-1:${data.aws_caller_identity.current.account_id}:table/pb_day_metrics"
+        "arn:aws:dynamodb:us-west-1:${data.aws_caller_identity.current.account_id}:table/pb_day_metrics",
+        "arn:aws:dynamodb:us-west-1:${data.aws_caller_identity.current.account_id}:table/pb_category_day_metrics",
         ]
       },
       {
@@ -334,9 +335,15 @@ resource "aws_s3_bucket_object" "day_metrics_dag" {
   content_type = "text/x-python"
 }
 
+resource "aws_s3_bucket_object" "category_day_metrics_dag" {
+  bucket = aws_s3_bucket.dags.bucket
+  source = "../dags/category_day_metrics.py"
+  key    = "category_day_metrics.py"
+  content_type = "text/x-python"
+}
+
 
 #### cron docker up scheduler
-
 resource "aws_scheduler_schedule" "daily_script_schedule" {
   name       = "daily-docker-up-scheduler"
   group_name = "default"

--- a/terraform/airflow/start_airflow.sh
+++ b/terraform/airflow/start_airflow.sh
@@ -12,13 +12,16 @@ log "Current directory: $(pwd)"
 cd airflow
 log "Current directory: $(pwd)"
 log "Copy dag"
+# todo: remove cp , only have in user data or separate job for checking
 aws s3 cp s3://pb-dags/day_metrics.py /home/ec2-user/airflow/dags/day_metrics.py >> "$LOG_FILE" 2>&1
+aws s3 cp s3://pb-dags/category_day_metrics.py /home/ec2-user/airflow/dags/category_day_metrics.py >> "$LOG_FILE" 2>&1
 
 # ensure variables
 export AIRFLOW_UID=$(id -u ec2-user)
 echo "AIRFLOW_UID=$(id -u ec2-user)" > .env
 echo "POSTGRES_USER=airflow" > .env
 echo "POSTGRES_PASSWORD=airflow" > .env
+
 log "Environment: $(env)"
 
 log "Start Docker"
@@ -32,4 +35,5 @@ sleep 30
 log "Unpause dag"
 # ensure dag unpaused
 docker exec airflow-airflow-scheduler-1 airflow dags unpause day_metrics >> "$LOG_FILE" 2>&1
+docker exec airflow-airflow-scheduler-1 airflow dags unpause category_day_metrics >> "$LOG_FILE" 2>&1
 log "Script completed"

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -309,3 +309,30 @@ resource "aws_dynamodb_table" "task_lists" {
     enabled = true
   }
 }
+
+
+resource "aws_dynamodb_table" "category_day_metrics" {
+  name = "pb_category_day_metrics"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "category_date_id"
+
+  attribute {
+    name = "category_date_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "user_id"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "UserIndex"
+    hash_key        = "user_id"
+    projection_type = "ALL"
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+}


### PR DESCRIPTION
Updates:
- daily airflow dag for creating category day metrics
- table used for creating downstream tables


Testing:
Fields populated
- category_date_id : category_uid + ":" + YYYY-MM-DD
- planned_minutes
- total_minutes
- fulfillment_score : capped at 100
- consistency_score : 1 or 0


To do:
refactor day metrics to use this