### PR TITLE
feat(milestones) milestones sessions line chart

### DIFF
--- a/frontend-web/src/components/charts/MinutesLineChart.jsx
+++ b/frontend-web/src/components/charts/MinutesLineChart.jsx
@@ -1,0 +1,115 @@
+import { useRef, useEffect } from "react";
+import { Chart, registerables, Colors } from "chart.js";
+import { format } from "date-fns";
+
+Chart.register(...registerables, Colors);
+Chart.defaults.font.family = "Inter";
+
+const SessionMinutesLineChart = ({ sessions, showLegend = true }) => {
+  const chartRef = useRef(null);
+  const chartInstance = useRef(null);
+
+  useEffect(() => {
+    const sortedSessions = [...sessions].sort(
+      (a, b) => new Date(a.event_startdate) - new Date(b.event_startdate)
+    );
+    const xAxisDates = sortedSessions.map((session) => session.event_startdate); // 2025-04-25 , 2025-08-05
+    const yAxisMinutes = sortedSessions.map((session) => session.minutes); // 30 , 30
+    const data = {
+      labels: xAxisDates,
+      datasets: [
+        {
+          label: "Minutes",
+          data: yAxisMinutes,
+          backgroundColor: "rgba(75, 192, 192, 0.5)",
+          borderColor: "rgba(75, 192, 192, 1)",
+          borderWidth: 1,
+          barPercentage: 0.2, // Narrow bars
+          categoryPercentage: 0.8,
+        },
+      ],
+    };
+    if (chartInstance.current) {
+      chartInstance.current.destroy();
+    }
+    const ctx = chartRef.current.getContext("2d");
+    const options = {
+      display: true,
+      responsive: true,
+      maintainAspectRatio: false,
+      fullSize: true,
+      plugins: {
+        legend: {
+          display: showLegend,
+          position: "bottom",
+          align: "start",
+          labels: {
+            color: "#FFFFFF",
+            font: {
+              size: 13,
+              weight: "normal",
+            },
+            boxWidth: 15,
+            usePointStyle: true,
+            pointStyle: "circle",
+            padding: 10,
+          },
+        },
+        tooltip: {
+          mode: "index",
+          intersect: false,
+        },
+      },
+      colors: {
+        forceOverride: true,
+      },
+      scales: {
+        x: {
+          type: "category", // 'category' for string labels
+          ticks: {
+            color: "#FFFFFF",
+            callback: function (val, index, ticks) {
+              const dateString = this.getLabelForValue(val);
+              const date = new Date(dateString + "T00:00:00");
+              return [
+                format(date, "EEE"), // First Line Short Day
+                format(date, "MMM d"), // Second Line Short Month , day
+              ];
+            },
+            autoSkip: true, // Try to skip labels if they overlap
+            maxRotation: 0, // Prevent rotating
+            minRotation: 0, // Prevent rotating
+            stepSize: xAxisDates.length > 7 ? 2 : 1, // Skip labels
+          },
+          grid: {
+            color: "rgba(255, 255, 255, 0.1)",
+          },
+        },
+        y: {
+          min: 0,
+          ticks: {
+            stepSize: 20,
+            color: "#b3fcfc",
+          },
+        },
+      },
+      interaction: {
+        mode: "nearest",
+        axis: "x",
+        intersect: false,
+      },
+    };
+    chartInstance.current = new Chart(ctx, {
+      type: "bar",
+      data: data,
+      options: options,
+    });
+    return () => {
+      chartInstance.current?.destroy();
+    };
+  }, [sessions]);
+
+  return <canvas ref={chartRef} className="w-full h-full" />;
+};
+
+export default SessionMinutesLineChart;

--- a/frontend-web/src/routes/Milestones.jsx
+++ b/frontend-web/src/routes/Milestones.jsx
@@ -6,7 +6,7 @@ import {
   useDeleteMilestone,
 } from "../hooks/useMilestones.jsx";
 import { useMilestoneSessions } from "@/hooks/useMilestoneSession.jsx";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
   Table,
   TableBody,
@@ -39,6 +39,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+// import LineChart from "../components/charts/LineChart.jsx";
+import SessionMinutesLineChart from "@/components/charts/MinutesLineChart.jsx";
 
 const baseContainerClasses = `
   // scrollable full background display
@@ -48,6 +50,17 @@ const baseContainerClasses = `
   p-10 md:pl-15 md:pr-15 sm:pt-12  text-white
   flex flex-col
 `;
+
+// array of all days
+function getDaysBetweenDates(startDate, endDate) {
+  const dates = [];
+  let currentDate = new Date(startDate);
+  while (isBefore(currentDate, endDate) || isEqual(currentDate, endDate)) {
+    dates.push(format(currentDate, "yyyy-MM-dd"));
+    currentDate = addDays(currentDate, 1);
+  }
+  return dates;
+}
 
 const Milestones = () => {
   const { data: categories, isLoading, error } = useCategories();
@@ -138,6 +151,11 @@ const Milestones = () => {
   const milestoneNumberSessions = selectedSessions.length;
   const milestoneHours = Math.floor(milestoneMinutes / 60);
   const milestoneMinutesRemainder = milestoneMinutes % 60;
+
+  useEffect(() => {
+    console.log(selectedSessions);
+  }, [selectedSessions]);
+  // const daysInCurrentRange = getDaysBetweenDates(startDate.date, endDate.date);
 
   // Adding new one
   const submitAddMilestone = () => {
@@ -384,7 +402,19 @@ const Milestones = () => {
             </span>
           </div>
         </div>
-        {/* TODO: Little Chart - with forecasting */}
+
+        {/* Sessions Chart */}
+        {selectedSessions.length > 0 && (
+          <div className="flex flex-row items-center justify-center">
+            <div className="p-4 mr-1 rounded-lg shadow-lg h-[200px] md:h-[225px] w-3/4 ">
+              <SessionMinutesLineChart
+                sessions={selectedSessions}
+                showLegend={false}
+              />
+            </div>
+          </div>
+        )}
+
         {/* Sessions Log */}
         <div className="flex flex-col mt-6 md:ml-10 md:mr-10 bg-coolgray rounded-lg gap-1">
           <div className="rounded-lg pt-3 text-lg">


### PR DESCRIPTION
Updates:
- Line chart in milestones page
- Uses most recent day for end of axis, first day of sessions for start of axis

Testing:
- matching sessions data, container collapses if no sessions to graph

<img width="611" height="819" alt="image" src="https://github.com/user-attachments/assets/26690272-753b-4503-bb97-db978c974dc1" />
