### PR TITLE
feat(range-view) kpi gauge charts in range view

### DIFF
--- a/frontend-web/src/components/charts/RangeGaugeRegion.jsx
+++ b/frontend-web/src/components/charts/RangeGaugeRegion.jsx
@@ -1,0 +1,186 @@
+import HalfCircleGauge from "@/components/charts/gaugeChart.jsx";
+import { useMemo } from "react";
+
+function stdDev(arr) {
+  const mean = arr.reduce((sum, v) => sum + v, 0) / arr.length;
+  const variance =
+    arr.reduce((sum, v) => sum + (v - mean) ** 2, 0) / arr.length;
+  return Math.sqrt(variance);
+}
+
+const calculateTrend = (data) => {
+  if (!data || data.length < 2) {
+    return 0;
+  }
+
+  let sumX = 0; // sum day indices
+  let sumY = 0; // sum metric
+  let sumXY = 0; // sum (day * metric) products
+  let sumX2 = 0; // sum of squared day indices
+  const n = data.length;
+
+  for (let i = 0; i < n; i++) {
+    const x = i; // day index
+    const y = data[i]; // metric value
+
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumX2 += x * x;
+  }
+
+  const numerator = n * sumXY - sumX * sumY; // covariance of x & y
+  const denominator = n * sumX2 - sumX * sumX; // variance of x
+  if (denominator === 0) {
+    return 0;
+  }
+  const slope = (numerator / denominator).toFixed(2);
+  return slope;
+};
+
+function calculateMetrics(events, categories, daysArray) {
+  const categoriesMap = new Map();
+  categories.forEach((cat) => {
+    categoriesMap.set(cat.category, cat);
+  });
+  // 1. Initialize datasets for each category with 0s for each day, ie {'Mindfulness': [0, 0, ...] , ...}
+  let category_datasets = {};
+  for (const category of categories) {
+    category_datasets[category.category] = new Array(daysArray.length).fill(0);
+  }
+  // 2. Add each event's minutes to corresponding category's day index
+  for (const event of events) {
+    const dayIndex = daysArray.indexOf(event.start_date); // Both are'YYYY-MM-DD'
+    if (category_datasets[event.category] && dayIndex !== -1) {
+      category_datasets[event.category][dayIndex] += event.minutes;
+    } else {
+      console.warn(
+        `Event with category '${event.category}' or date '${event.start_date}' could not be processed.`
+      );
+    }
+  }
+  // 3. Divide each day's total minutes by its category's time, convert to whole percentage
+  const finalCategoryPercentages = {};
+  // category dataset keys category names
+  for (const categoryName in category_datasets) {
+    if (category_datasets.hasOwnProperty(categoryName)) {
+      // Skip prototype properties
+      const dailyMinutesArray = category_datasets[categoryName];
+      const categoryData = categoriesMap.get(categoryName);
+      if (categoryData && categoryData.minutes !== undefined) {
+        const categoryTime = categoryData.minutes;
+        // iterate through the indices of the day arrays
+        finalCategoryPercentages[categoryName] = dailyMinutesArray.map(
+          (dailyMinutes) => {
+            if (categoryTime === 0) {
+              // Avoid division by zero
+              return 1;
+            }
+            const percentage = (dailyMinutes / categoryTime) * 100;
+            return Math.min(percentage, 100);
+          }
+        );
+      } else {
+        finalCategoryPercentages[categoryName] = new Array(
+          daysArray.length
+        ).fill(0);
+        console.warn(`Missing minutes limit for category: ${categoryName}.`);
+      }
+    }
+  }
+  console.log(finalCategoryPercentages);
+
+  const series = Object.values(finalCategoryPercentages); // array of per-category arrays
+  const n = series.length || 1;
+
+  let avgMeanRounded = 0;
+  let trendSlope = 0;
+  let balance = 0;
+
+  const { sumByDay, countByDay } = series.reduce(
+    (acc, arr) => {
+      for (let i = 0; i < daysArray.length; i++) {
+        const v = arr[i];
+        if (Number.isFinite(v)) {
+          acc.sumByDay[i] += v;
+          acc.countByDay[i] += 1;
+        }
+      }
+      return acc;
+    },
+    {
+      sumByDay: new Array(daysArray.length).fill(0),
+      countByDay: new Array(daysArray.length).fill(0),
+    }
+  );
+
+  const meanByDay = sumByDay.map((s, i) =>
+    countByDay[i] ? s / countByDay[i] : 0
+  );
+
+  trendSlope = calculateTrend(meanByDay);
+
+  const avgMean =
+    meanByDay.reduce((sum, val) => sum + val, 0) / meanByDay.length;
+  avgMeanRounded = Math.round(avgMean);
+
+  // --- pass 2: variance by day (population variance) ---
+  const varSumByDay = series.reduce((acc, arr) => {
+    for (let i = 0; i < daysArray.length; i++) {
+      const v = arr[i];
+      if (Number.isFinite(v)) {
+        const diff = v - meanByDay[i];
+        acc[i] += diff * diff;
+      }
+    }
+    return acc;
+  }, new Array(daysArray.length).fill(0));
+
+  const varianceByDay = varSumByDay.map((s, i) =>
+    countByDay[i] ? s / countByDay[i] : 0
+  );
+  // If you want *sample* variance instead, use: s / Math.max(1, countByDay[i] - 1)
+
+  const stdDevByDay = varianceByDay.map(Math.sqrt);
+
+  // Optional: single KPI (avg std dev across days), normalized to 0–100 where higher = more balanced
+  const avgStd =
+    stdDevByDay.reduce((a, b) => a + b, 0) / (stdDevByDay.length || 1);
+  const balanceScore = 100 * (1 - avgStd / 50); // same as 100 - 2*avgStd
+  const roundedBalanceScore = Math.round(balanceScore);
+
+  return {
+    avgFulfillment: avgMeanRounded,
+    balance: roundedBalanceScore,
+    trend: trendSlope,
+  };
+}
+
+const RangeGaugeRegion = ({ events, categories, daysArray }) => {
+  const results = useMemo(
+    () => calculateMetrics(events, categories, daysArray),
+    [events, categories, daysArray]
+  );
+
+  const fulfillment = results?.avgFulfillment ?? 0;
+  const balance = results?.balance ?? 0;
+  const trend = results?.trend ?? 0;
+
+  return (
+    <div className="-mx-10 -p sm:mx-0">
+      <div className="flex justify-center items-center gap-4 sm:gap-10 h-18 sm:h-16 md:h-20">
+        <div className="h-full aspect-[1/1] shrink-0">
+          <HalfCircleGauge metricName="Fulfillment" score={fulfillment} />
+        </div>
+        <div className="h-full aspect-[1/1] shrink-0">
+          <HalfCircleGauge metricName="Balance" score={balance} />
+        </div>
+        <div className="h-full aspect-[1/1] shrink-0">
+          <HalfCircleGauge metricName="Trend" score={trend} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RangeGaugeRegion;

--- a/frontend-web/src/components/charts/gaugeChart.jsx
+++ b/frontend-web/src/components/charts/gaugeChart.jsx
@@ -63,7 +63,7 @@ const HalfCircleGauge = ({ metricName, score }) => {
           detail: {
             valueAnimation: true,
             offsetCenter: [0, "5px"], // lower -> left center score metric , higher -> down center score metric
-            fontSize: valueFont,
+            fontSize: isPos ? valueFont : valueFont - 2,
             fontWeight: "bolder",
             formatter: `{value}\n{name|${metricName}}`,
             rich: {
@@ -72,7 +72,9 @@ const HalfCircleGauge = ({ metricName, score }) => {
                 lineHeight: Math.round(nameFont * 1.6),
                 fontWeight: "normal",
                 color: "#ffffff",
-                padding: [8, 0, 0, 0],
+                padding: [5, 0, 0, 0],
+                fontFamily: "Inter, sans-serif",
+                letterSpacing: 1.7, // in px
               },
             },
             color: isPos ? "rgba(201,238,255,1)" : "rgba(212, 149, 144, 1)",

--- a/frontend-web/src/components/charts/gaugeChart.jsx
+++ b/frontend-web/src/components/charts/gaugeChart.jsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useRef } from "react";
+import * as echarts from "echarts";
+
+const HalfCircleGauge = ({ metricName, score }) => {
+  const chartRef = useRef(null);
+  const chart = useRef(null);
+  const ro = useRef(null);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+    chart.current = echarts.init(chartRef.current);
+
+    // Resize on container changes
+    ro.current = new ResizeObserver(() => {
+      chart.current?.resize();
+    });
+    ro.current.observe(chartRef.current);
+
+    return () => {
+      ro.current?.disconnect();
+      chart.current?.dispose();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!chart.current || score == null) return;
+
+    const h = chartRef.current?.clientHeight || 30; // container height
+    const ring = Math.max(6, Math.round(h * 0.1)); // ~10% thickness
+    const thin = Math.max(3, Math.round(h * 0.02)); // thin highlight
+    const valueFont = Math.max(14, Math.round(h * 0.35));
+    const nameFont = Math.max(13, Math.round(h * 0.15));
+    const pos = Math.max(0, score);
+    const neg = Math.max(0, -score);
+    const isPos = pos > 0;
+
+    chart.current.setOption({
+      tooltip: { formatter: (p) => `${metricName}: ${p.value}` },
+      series: [
+        // Progress Line
+        {
+          type: "gauge",
+          startAngle: 180, // start pi/2
+          endAngle: 0, // end 0
+          min: 0, // scores out of 100
+          max: 100,
+          center: ["50%", "50%"], // lower -> left center line, lower -> higher line
+          radius: "100%", // size of the arc
+          itemStyle: {
+            color: new echarts.graphic.RadialGradient(0.5, 0.5, 0.45, [
+              { offset: 0, color: "rgba(76,197,207,0.8)" },
+              { offset: 1, color: "rgba(201,238,255,1)" },
+            ]),
+          },
+          progress: { show: true, width: ring },
+          pointer: { show: false },
+          axisLine: { show: false },
+          axisTick: { show: false },
+          splitLine: { show: false },
+          axisLabel: { show: false },
+          anchor: { show: false },
+          title: { show: false },
+          detail: {
+            valueAnimation: true,
+            offsetCenter: [0, "5px"], // lower -> left center score metric , higher -> down center score metric
+            fontSize: valueFont,
+            fontWeight: "bolder",
+            formatter: `{value}\n{name|${metricName}}`,
+            rich: {
+              name: {
+                fontSize: nameFont,
+                lineHeight: Math.round(nameFont * 1.6),
+                fontWeight: "normal",
+                color: "#ffffff",
+                padding: [8, 0, 0, 0],
+              },
+            },
+            color: isPos ? "rgba(201,238,255,1)" : "rgba(212, 149, 144, 1)",
+          },
+          data: [{ value: score }],
+        },
+        {
+          type: "gauge",
+          clockwise: false,
+          min: 0,
+          max: 100,
+          startAngle: 0,
+          endAngle: 180, // <-- reversed
+          center: ["50%", "50%"],
+          radius: "101%",
+          progress: { show: true, width: ring },
+          pointer: { show: false },
+          axisLine: { show: false },
+          axisTick: { show: false },
+          splitLine: { show: false },
+          axisLabel: { show: false },
+          itemStyle: {
+            color: new echarts.graphic.RadialGradient(0.65, 0.4, 0.75, [
+              { offset: 0, color: "rgba(120, 75, 72,0.8)" },
+              { offset: 1, color: "rgba(199, 136, 131,1)" },
+            ]),
+          },
+          detail: { show: false }, // label handled by the first series
+          data: [{ value: neg }], // 0 if positive
+          z: 2,
+        },
+        // Accent Line
+        {
+          type: "gauge",
+          startAngle: 180,
+          endAngle: 0,
+          min: 0,
+          max: 100,
+          center: ["50%", "50%"], // lower -> left center thick line, lower -> higher thick line
+          radius: "100%",
+          itemStyle: { color: "#B3FCFC" },
+          progress: { show: true, width: thin },
+          pointer: { show: false },
+          axisLine: { show: false },
+          axisTick: { show: false },
+          splitLine: { show: false },
+          axisLabel: { show: false },
+          detail: { show: false },
+          data: [{ value: score }],
+        },
+      ],
+    });
+  }, [metricName, score]);
+
+  return <div ref={chartRef} className="w-full h-full" />;
+};
+
+export default HalfCircleGauge;

--- a/frontend-web/src/routes/Range-view.jsx
+++ b/frontend-web/src/routes/Range-view.jsx
@@ -8,13 +8,14 @@ import CategoryTotals from "../components/charts/CategoryTotals.jsx";
 import NavButton from "../components/NavButton.jsx";
 import { useCategories } from "../hooks/useCategories.jsx";
 import { useEventsForRange } from "../hooks/useEventsForRange.jsx";
+import RangeGaugeRegion from "@/components/charts/RangeGaugeRegion.jsx";
 
 const baseContainerClasses = `
   // scrollable full background display
   w-screen min-h-screen h-auto m-0
   bg-[#000000] bg-cover bg-center
   // global margins
-  pt-5 pl-5 pr-5 pb-5 sm:pt-12 sm:pl-20
+  pt-5 pl-2 pr-5 pb-5 sm:pt-12 sm:pl-20
   text-white
   flex flex-col
 `;
@@ -286,7 +287,16 @@ const RangeView = () => {
             </div>
           </div>
         )}
+
         {/* Charts */}
+        <RangeGaugeRegion
+          events={filteredEventsForVisuals}
+          categories={categories.filter((item) =>
+            selectedCategoriesMap.has(item.category)
+          )}
+          daysArray={daysInCurrentRange}
+        />
+
         <div className="flex flex-col md:flex-row items-center">
           {/* Line Chart */}
           <div className="p-4 mx-auto rounded-lg shadow-lg h-[350px] md:h-[400px] w-full md:w-3/4">
@@ -322,6 +332,7 @@ const RangeView = () => {
           </div>
         </div>
       </div>
+
       <div className="fixed bottom-4 right-4 p-1 rounded-full ">
         <NavButton direction="up" />
       </div>


### PR DESCRIPTION
Updates:
- Avg Fulfillment , Avg Balance kpi , Trend kpi gauge charts in Range View
    - Graph updates as day filter changed, category filter changed
- Avg Fulfillment: avg fulfillment scores by day , averaged
- Avg Balance: standard deviation of fulfillment socres by day , averaged
- Trend: linear regression of fulfillment scores
- Using temporary calculations on raw event data like the chart in range view, should be refactored to use pb_category_day_metrics instead


Testing:
- negative data creates arc up & to the left, positive data creates arc up & to the right
- gauge cards fit on mobile
- calculations match data


To do:
- tooltip for info like in category
- switch to pb_category_day_metrics in range view